### PR TITLE
Fix indent-related compiler warning

### DIFF
--- a/src/display/font.cpp
+++ b/src/display/font.cpp
@@ -160,10 +160,9 @@ void SharedFontState::initFontSetCB(SDL_RWops &ops,
 _TTF_Font *SharedFontState::getFont(std::string family,
                                     int size)
 {
-    
-    if (family.empty())
-        family = p->defaultFamily;
-    
+	if (family.empty())
+		family = p->defaultFamily;
+
 	/* Check for substitutions */
 	if (p->subs.contains(family))
 		family = p->subs[family];


### PR DESCRIPTION
Some tab/space confusion was causing a compiler warning (because the indentation resembled a GoToFail bug). This PR fixes the whitespace to be consistent and avoid the warning. My understanding from reading the code is that the warning was a false positive, and the logic of the code was correct, but it would be useful if you can confirm that before merging this.