### PR TITLE
Update JIT for Ruby v3.1.0+

### DIFF
--- a/binding/binding-mri.cpp
+++ b/binding/binding-mri.cpp
@@ -1114,6 +1114,10 @@ static void mriBindingExecute() {
         rubyArgsC.push_back(maxCache.c_str());
         rubyArgsC.push_back(minCalls.c_str());
         node = ruby_options(rubyArgsC.size(), const_cast<char**>(rubyArgsC.data()));
+    } else if (conf.yjit.enabled) {
+        rubyArgsC.push_back("--yjit");
+        // TODO: Maybe support --yjit-exec-mem-size, --yjit-call-threshold
+        node = ruby_options(rubyArgsC.size(), const_cast<char**>(rubyArgsC.data()));
     } else {
         node = ruby_options(rubyArgsC.size(), const_cast<char**>(rubyArgsC.data()));
     }

--- a/binding/binding-mri.cpp
+++ b/binding/binding-mri.cpp
@@ -1094,10 +1094,22 @@ static void mriBindingExecute() {
     rubyArgsC.push_back("-e ");
     void *node;
     if (conf.jit.enabled) {
-        std::string verboseLevel("--jit-verbose="); verboseLevel += std::to_string(conf.jit.verboseLevel);
-        std::string maxCache("--jit-max-cache="); maxCache += std::to_string(conf.jit.maxCache);
-        std::string minCalls("--jit-min-calls="); minCalls += std::to_string(conf.jit.minCalls);
+#if RAPI_FULL >= 310
+        // Ruby v3.1.0 renamed the --jit options to --mjit.
+        std::string verboseLevel("--mjit-verbose=");
+        std::string maxCache("--mjit-max-cache=");
+        std::string minCalls("--mjit-min-calls=");
+        rubyArgsC.push_back("--mjit");
+#else
+        std::string verboseLevel("--jit-verbose=");
+        std::string maxCache("--jit-max-cache=");
+        std::string minCalls("--jit-min-calls=");
         rubyArgsC.push_back("--jit");
+#endif
+        verboseLevel += std::to_string(conf.jit.verboseLevel);
+        maxCache += std::to_string(conf.jit.maxCache);
+        minCalls += std::to_string(conf.jit.minCalls);
+
         rubyArgsC.push_back(verboseLevel.c_str());
         rubyArgsC.push_back(maxCache.c_str());
         rubyArgsC.push_back(minCalls.c_str());

--- a/mkxp.json
+++ b/mkxp.json
@@ -315,6 +315,7 @@
     // Determines whether MJIT is enabled. This probably
     // won't work unless you also have the header file
     // that it needs. Only works with Ruby 2.6 or higher.
+    // This Ruby feature is experimental.
     // (default: false)
     //
     // "JITEnable": false,
@@ -338,6 +339,12 @@
     //
     // "JITMinCalls": 10000,
 
+    // Determines whether YJIT is enabled.
+    // Only works with Ruby 3.1 or higher.
+    // This Ruby feature is experimental.
+    // (default: false)
+    //
+    // "YJITEnable": false,
 
     // SoundFont to use for midi playback (via fluidsynth)
     // (default: none)

--- a/mkxp.json
+++ b/mkxp.json
@@ -312,7 +312,7 @@
     // "rubyLoadpath": ["/usr/lib64/ruby/",
     //                  "/usr/local/share/ruby/site_ruby"],
 
-    // Determines whether JIT is enabled. This probably
+    // Determines whether MJIT is enabled. This probably
     // won't work unless you also have the header file
     // that it needs. Only works with Ruby 2.6 or higher.
     // (default: false)
@@ -320,20 +320,20 @@
     // "JITEnable": false,
     
     // Determines what level of verbosity to use when
-    // logging JIT events. Starts at 0, which is next
+    // logging MJIT events. Starts at 0, which is next
     // to nothing. Set it higher to see more.
     // (default: 0)
     //
     // "JITVerboseLevel": 0,
     
     // Determines how many compiled methods that Ruby
-    // will keep in its cache.
+    // will keep in its MJIT cache.
     // (default: 100)
     //
     // "JITMaxCache": 100,
     
     // Determines how many times a function has to be
-    // called before it is compiled.
+    // called before it is compiled by MJIT.
     // (default: 10000)
     //
     // "JITMinCalls": 10000,

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -180,6 +180,7 @@ void Config::read(int argc, char *argv[]) {
         {"JITVerboseLevel", 0},
         {"JITMaxCache", 100},
         {"JITMinCalls", 10000},
+        {"YJITEnable", false},
         {"bindingNames", json::object({
             {"a", "A"},
             {"b", "B"},
@@ -231,6 +232,7 @@ try { exp } catch (...) {}
     SET_OPT_CUSTOMKEY(jit.verboseLevel, JITVerboseLevel, integer);
     SET_OPT_CUSTOMKEY(jit.maxCache, JITMaxCache, integer);
     SET_OPT_CUSTOMKEY(jit.minCalls, JITMinCalls, integer);
+    SET_OPT_CUSTOMKEY(yjit.enabled, YJITEnable, boolean);
     SET_OPT(rgssVersion, integer);
     SET_OPT(defScreenW, integer);
     SET_OPT(defScreenH, integer);

--- a/src/config.h
+++ b/src/config.h
@@ -114,7 +114,7 @@ struct Config {
         std::string title;
     } game;
     
-    // JIT Options
+    // MJIT Options
     struct {
         bool enabled;
         int verboseLevel;
@@ -122,6 +122,11 @@ struct Config {
         int minCalls;
     } jit;
     
+    // YJIT Options
+    struct {
+        bool enabled;
+    } yjit;
+
     // Keybinding action name mappings
     struct {
         std::string a;


### PR DESCRIPTION
MJIT support was broken in mkxp-z on current Ruby versions. Current Ruby versions also added YJIT, which is much faster on supported platforms.