### PR TITLE
Add "displayFPS" config option

### DIFF
--- a/mkxp.json
+++ b/mkxp.json
@@ -34,6 +34,13 @@
     // "rgssVersion": 1,
 
 
+    // Continuously display average FPS in window title.
+    // This can always be toggled with F2 at runtime.
+    // (default: disabled)
+    //
+    // "displayFPS": false,
+
+
     // Continuously print average FPS to console.
     // This setting does not affect the window title
     // FPS display toggled via F2

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -129,6 +129,7 @@ void Config::read(int argc, char *argv[]) {
     auto optsJ = json::object({
         {"rgssVersion", 0},
         {"debugMode", false},
+        {"displayFPS", false},
         {"printFPS", false},
         {"winResizable", true},
         {"fullscreen", false},
@@ -250,6 +251,7 @@ try { exp } catch (...) {}
     // now RESUME
     
     SET_OPT(debugMode, boolean);
+    SET_OPT(displayFPS, boolean);
     SET_OPT(printFPS, boolean);
     SET_OPT(fullscreen, boolean);
     SET_OPT(fixedAspectRatio, boolean);

--- a/src/config.h
+++ b/src/config.h
@@ -37,6 +37,7 @@ struct Config {
     bool debugMode;
     bool winConsole;
     bool preferMetalRenderer;
+    bool displayFPS;
     bool printFPS;
     
     bool winResizable;

--- a/src/eventthread.cpp
+++ b/src/eventthread.cpp
@@ -152,11 +152,11 @@ void EventThread::process(RGSSThreadData &rtData)
     fullscreen = rtData.config.fullscreen;
     int toggleFSMod = rtData.config.anyAltToggleFS ? KMOD_ALT : KMOD_LALT;
     
-    if (rtData.config.printFPS)
+    bool displayingFPS = rtData.config.displayFPS;
+    
+    if (displayingFPS || rtData.config.printFPS)
         fps.sendUpdates.set();
-    
-    bool displayingFPS = false;
-    
+
     bool cursorInWindow = false;
     /* Will be updated eventually */
     SDL_Rect gameScreen = { 0, 0, 0, 0 };


### PR DESCRIPTION
Seemed kind of lame that `printFPS` was configurable in JSON but not `displayFPS`, so I fixed that.