### PR TITLE
Make font families case insensitive

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -266,6 +266,9 @@ try { exp } catch (...) {}
     SET_OPT(frameSkip, boolean);
     SET_OPT(syncToRefreshrate, boolean);
     fillStringVec(opts["solidFonts"], solidFonts);
+    for (std::string & solidFont : solidFonts)
+        std::transform(solidFont.begin(), solidFont.end(), solidFont.begin(),
+            [](unsigned char c) { return std::tolower(c); });
 #ifdef __APPLE__
     SET_OPT(preferMetalRenderer, boolean);
 #endif
@@ -288,6 +291,9 @@ try { exp } catch (...) {}
     fillStringVec(opts["preloadScript"], preloadScripts);
     fillStringVec(opts["RTP"], rtps);
     fillStringVec(opts["fontSub"], fontSubs);
+    for (std::string & fontSub : fontSubs)
+        std::transform(fontSub.begin(), fontSub.end(), fontSub.begin(),
+            [](unsigned char c) { return std::tolower(c); });
     fillStringVec(opts["rubyLoadpath"], rubyLoadpaths);
     
     auto &bnames = opts["bindingNames"].as_object();

--- a/src/display/font.cpp
+++ b/src/display/font.cpp
@@ -30,6 +30,8 @@
 
 #include <string>
 #include <utility>
+#include <algorithm>
+#include <cctype>
 
 #ifdef MKXPZ_BUILD_XCODE
 #include "filesystem/filesystem.h"
@@ -147,6 +149,9 @@ void SharedFontState::initFontSetCB(SDL_RWops &ops,
 	std::string family = TTF_FontFaceFamilyName(font);
 	std::string style = TTF_FontFaceStyleName(font);
 
+	std::transform(family.begin(), family.end(), family.begin(),
+		[](unsigned char c){ return std::tolower(c); });
+
 	TTF_CloseFont(font);
 
 	FontSet &set = p->sets[family];
@@ -160,6 +165,9 @@ void SharedFontState::initFontSetCB(SDL_RWops &ops,
 _TTF_Font *SharedFontState::getFont(std::string family,
                                     int size)
 {
+	std::transform(family.begin(), family.end(), family.begin(),
+		[](unsigned char c){ return std::tolower(c); });
+
 	if (family.empty())
 		family = p->defaultFamily;
 
@@ -217,6 +225,9 @@ _TTF_Font *SharedFontState::getFont(std::string family,
 
 bool SharedFontState::fontPresent(std::string family) const
 {
+	std::transform(family.begin(), family.end(), family.begin(),
+		[](unsigned char c){ return std::tolower(c); });
+
 	/* Check for substitutions */
 	if (p->subs.contains(family))
 		family = p->subs[family];


### PR DESCRIPTION
RPG Maker, like most applications, lets developers access font families in a case insensitive way. This PR brings makes mkxp-z do that, too.