### PR TITLE
Add Ruby binding to fileSystem()->exist as System.file_exist?

### DIFF
--- a/binding/binding-mri.cpp
+++ b/binding/binding-mri.cpp
@@ -133,6 +133,7 @@ RB_METHOD(mkxpSystemMemory);
 RB_METHOD(mkxpReloadPathCache);
 RB_METHOD(mkxpAddPath);
 RB_METHOD(mkxpRemovePath);
+RB_METHOD(mkxpFileExists);
 RB_METHOD(mkxpLaunch);
 
 RB_METHOD(mkxpGetJSONSetting);
@@ -243,6 +244,7 @@ static void mriBindingInit() {
     _rb_define_module_function(mod, "reload_cache", mkxpReloadPathCache);
     _rb_define_module_function(mod, "mount", mkxpAddPath);
     _rb_define_module_function(mod, "unmount", mkxpRemovePath);
+    _rb_define_module_function(mod, "file_exist?", mkxpFileExists);
     _rb_define_module_function(mod, "launch", mkxpLaunch);
     
     _rb_define_module_function(mod, "default_font_family=", mkxpSetDefaultFontFamily);
@@ -572,6 +574,18 @@ RB_METHOD(mkxpRemovePath) {
         raiseRbExc(e);
     }
     return path;
+}
+
+RB_METHOD(mkxpFileExists) {
+    RB_UNUSED_PARAM;
+    
+    VALUE path;
+    rb_scan_args(argc, argv, "1", &path);
+    SafeStringValue(path);
+    
+    if (shState->fileSystem().exists(RSTRING_PTR(path)))
+        return Qtrue;
+    return Qfalse;
 }
 
 RB_METHOD(mkxpSetDefaultFontFamily) {


### PR DESCRIPTION
Unsure if there's any performance benefit to this, but it certainly looks cleaner than using wrapping load_data in begin rescue to determine if a file exists somewhere in the path cache.