### PR TITLE
Do not call gl.UseProgram(0) in shader destructor

### DIFF
--- a/src/display/gl/shader.cpp
+++ b/src/display/gl/shader.cpp
@@ -115,7 +115,6 @@ Shader::Shader()
 
 Shader::~Shader()
 {
-	gl.UseProgram(0);
 	gl.DeleteProgram(program);
 	gl.DeleteShader(vertShader);
 	gl.DeleteShader(fragShader);


### PR DESCRIPTION
Let me start by saying that the bug this fixes is _very_ tricky to reproduce given the nature of what happens. In practice, it may not even be a concern for most forks of mkxp.

In my setup to make this happen, I create a custom shader object, apply it to a Bitmap on the title screen. Then I mash to get to the file select scene as fast as possible. The blit operations that are supposed to take place do not operate as intended. Some blits do not appear, artifacts from unrelated textures end up in the resulting bitmap.

Intended result:
![image](https://github.com/mkxp-z/mkxp-z/assets/7004497/4684aaf9-d274-4823-9a62-96246b810886)

Erroneous results
![image](https://github.com/mkxp-z/mkxp-z/assets/7004497/749470be-8a17-42b7-8946-90e52f4b440e)
![image](https://github.com/mkxp-z/mkxp-z/assets/7004497/7e47775e-aac6-48a1-ae27-8b3e06325b44)

If I don't mash through fast enough, the issue does not present itself. My understanding is that garbage collection takes care of the shader object that is no longer needed, which then invokes the destructor. This behavior is correct. What is not correct is the call to `gl.UseProgram(0)`. It is not guaranteed that the GL state is currently using the to-be-destroyed shader object's program. If the timing lines up just right, mkxp could be clearing the program after another one has been set but before that new one finishes. Additionally, the step is simply not necessary, as [glDeleteProgram](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDeleteProgram.xhtml) already does what mkxp needs.

As a side note, I troubleshot this by changing my Ruby version because this did not appear on older builds. I could not reproduce this in Ruby 3.0.0, but it does occur in 3.1.3. I imagine something about garbage collection changed between the two.