### PR TITLE
Movie audio disposal bugfix

### DIFF
--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -402,13 +402,13 @@ struct Movie
             audioQueueHead = NULL;
             SDL_DestroyMutex(audioMutex);
             audioThreadTermReq.set();
+            if(audioThread) {
+                SDL_WaitThread(audioThread, 0);
+                audioThread = 0;
+            }
             alSourceStop(audioSource);
             alDeleteSources(1, &audioSource);
             alDeleteBuffers(STREAM_BUFS, alBuffers);
-        }
-        if(audioThread) {
-            SDL_WaitThread(audioThread, 0);
-            audioThread = 0;
         }
         if (video) THEORAPLAY_freeVideo(video);
         if (audio) THEORAPLAY_freeAudio(audio);


### PR DESCRIPTION
Put the audioThread check within the hasAudio conditional in the movie destructor. The order is significant, as trying to dispose of OpenAL objects before audioThread is complete can result in hanging or other undefined behavior.

I've tested this with audio video and audio-less video, before and after the changes. It seems to have fixed it, but I encourage testing with other videos you may have on hand.

Fixes #36.