### PR TITLE
Fix default value for useScriptNames setting

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -174,7 +174,7 @@ void Config::read(int argc, char *argv[]) {
         {"BGMTrackCount", 1},
         {"customScript", ""},
         {"pathCache", true},
-        {"useScriptNames", 1},
+        {"useScriptNames", true},
         {"preloadScript", json::array({})},
         {"RTP", json::array({})},
         {"fontSub", json::array({})},


### PR DESCRIPTION
Just a little bug I noticed.