### PR TITLE
Use GL_CLAMP_TO_BORDER instead of GL_CLAMP_TO_EDGE

### DIFF
--- a/src/display/gl/gl-util.h
+++ b/src/display/gl/gl-util.h
@@ -25,6 +25,14 @@
 #include "gl-fun.h"
 #include "etc-internal.h"
 
+#ifndef GL_CLAMP_TO_BORDER
+	#ifdef GL_CLAMP_TO_BORDER_NV
+		#define GL_CLAMP_TO_BORDER GL_CLAMP_TO_BORDER_NV
+	#else
+		#define GL_CLAMP_TO_BORDER GL_CLAMP_TO_EDGE
+	#endif
+#endif
+
 /* Struct wrapping GLuint for some light type safety */
 #define DEF_GL_ID \
 struct ID \
@@ -93,8 +101,8 @@ namespace TEX
 
 	static inline void setRepeat(bool mode)
 	{
-		gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, mode ? GL_REPEAT : GL_CLAMP_TO_EDGE);
-		gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, mode ? GL_REPEAT : GL_CLAMP_TO_EDGE);
+		gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, mode ? GL_REPEAT : GL_CLAMP_TO_BORDER);
+		gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, mode ? GL_REPEAT : GL_CLAMP_TO_BORDER);
 	}
 
 	static inline void setSmooth(bool mode)

--- a/src/display/gl/gl-util.h
+++ b/src/display/gl/gl-util.h
@@ -25,14 +25,6 @@
 #include "gl-fun.h"
 #include "etc-internal.h"
 
-#ifndef GL_CLAMP_TO_BORDER
-	#ifdef GL_CLAMP_TO_BORDER_NV
-		#define GL_CLAMP_TO_BORDER GL_CLAMP_TO_BORDER_NV
-	#else
-		#define GL_CLAMP_TO_BORDER GL_CLAMP_TO_EDGE
-	#endif
-#endif
-
 /* Struct wrapping GLuint for some light type safety */
 #define DEF_GL_ID \
 struct ID \
@@ -101,8 +93,8 @@ namespace TEX
 
 	static inline void setRepeat(bool mode)
 	{
-		gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, mode ? GL_REPEAT : GL_CLAMP_TO_BORDER);
-		gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, mode ? GL_REPEAT : GL_CLAMP_TO_BORDER);
+		gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, mode ? GL_REPEAT : GL_CLAMP_TO_BORDER_NV);
+		gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, mode ? GL_REPEAT : GL_CLAMP_TO_BORDER_NV);
 	}
 
 	static inline void setSmooth(bool mode)


### PR DESCRIPTION
What the title says, although our version of OpenGL is technically calling GL_CLAMP_TO_BORDER_NV. I think this only makes a difference if a game calls stretch_blt with a missized sourceRect. Without this fix, the outermost pixels of the source bitmap will get stretched to the edge of the blitted area. With it, the empty area will be transparent and the destination will keep what was originally there, which matches RPG Maker's behavior.