### PR TITLE
Autohide mouse cursor after half a second

### DIFF
--- a/src/eventthread.cpp
+++ b/src/eventthread.cpp
@@ -125,7 +125,7 @@ bool EventThread::allocUserEvents()
 EventThread::EventThread()
 : ctrl(0),
 fullscreen(false),
-showCursor(true)
+showCursor(false)
 {
     textInputLock = SDL_CreateMutex();
 }
@@ -133,6 +133,20 @@ showCursor(true)
 EventThread::~EventThread()
 {
     SDL_DestroyMutex(textInputLock);
+}
+
+SDL_TimerID hideCursorTimerID = 0;
+Uint32 cursorTimerCallback(Uint32 interval, void* param)
+{
+	EventThread *ethread = static_cast<EventThread*>(param);
+	hideCursorTimerID = 0;
+	ethread->requestShowCursor(ethread->getShowCursor());
+	return 0;
+}
+void EventThread::cursorTimer()
+{
+	SDL_RemoveTimer(hideCursorTimerID);
+	hideCursorTimerID = SDL_AddTimer(500, cursorTimerCallback, this);
 }
 
 void EventThread::process(RGSSThreadData &rtData)
@@ -445,6 +459,7 @@ void EventThread::process(RGSSThreadData &rtData)
             case SDL_MOUSEMOTION :
                 mouseState.x = event.motion.x;
                 mouseState.y = event.motion.y;
+                cursorTimer();
                 updateCursorState(cursorInWindow, gameScreen);
                 break;
                 
@@ -687,7 +702,7 @@ void EventThread::updateCursorState(bool inWindow,
     bool inScreen = inWindow && SDL_PointInRect(&pos, &screen);
     
     if (inScreen)
-        SDL_ShowCursor(showCursor ? SDL_TRUE : SDL_FALSE);
+        SDL_ShowCursor(showCursor || hideCursorTimerID ? SDL_TRUE : SDL_FALSE);
     else
         SDL_ShowCursor(SDL_TRUE);
 }

--- a/src/eventthread.h
+++ b/src/eventthread.h
@@ -124,6 +124,7 @@ private:
 	void setFullscreen(SDL_Window *, bool mode);
 	void updateCursorState(bool inWindow,
 	                       const SDL_Rect &screen);
+	void cursorTimer();
 
 	bool fullscreen;
 	bool showCursor;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -210,7 +210,7 @@ int main(int argc, char *argv[]) {
 #endif
 
     /* initialize SDL first */
-    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER) < 0) {
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER | SDL_INIT_TIMER) < 0) {
       showInitError(std::string("Error initializing SDL: ") + SDL_GetError());
       return 0;
     }


### PR DESCRIPTION
I'm changing the behavior of Graphics.show_cursor slightly. With this patch it defaults to false, and when it's set to false the cursor reappears for half a second when the mouse is moved,  which matches RPG Maker's behavior and I personally think looks nicer. Setting it to true makes the cursor always visible, which I can see being useful in some circumstances.