### PR TITLE
Prevent link to zlib1.dll

### DIFF
--- a/windows/Makefile
+++ b/windows/Makefile
@@ -150,6 +150,7 @@ $(DOWNLOADS)/libpng/Makefile: $(DOWNLOADS)/libpng/configure
 
 $(DOWNLOADS)/libpng/configure:
 	$(CLONE) $(GITHUB)/mkxp-z/libpng $(DOWNLOADS)/libpng
+	sed 's/zlib//g' -i $(DOWNLOADS)/libpng/libpng.pc.in
 
 # uchardet
 uchardet: init_dirs $(LIBDIR)/libuchardet.a


### PR DESCRIPTION
Honestly, I hate that I've had to resort to sed to accomplish this but I couldn't find another way, other than directly changing the libpng repository. If this solution isn't good enough, I completely understand.

In any case, I've tested it thoroughly; zlib now just links statically as intended, and zlib1.dll is no longer required.