### PR TITLE
Window resizing changed

### DIFF
--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -1625,7 +1625,19 @@ double Graphics::getScale() const {
 
 void Graphics::setScale(double factor) {
     p->threadData->rqWindowAdjust.wait();
-    factor = clamp(factor, 0.5, 4.0);
+    
+    int displayIndex = SDL_GetWindowDisplayIndex(shState->sdlWindow());
+    SDL_Rect displayRect;
+    SDL_GetDisplayUsableBounds(displayIndex, &displayRect);
+    
+    int top, bottom, left, right;
+    SDL_GetWindowBordersSize(shState->sdlWindow(), &top, &bottom, &left, &right);
+    
+    double maxWidth = displayRect.w;
+    double maxHeight = displayRect.h - top;
+    double maxScale = std::min(maxWidth / p->scRes.x, maxHeight / p->scRes.y);
+    
+    factor = clamp(factor, 0.5, maxScale);
     
     if (factor == getScale())
         return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -427,6 +427,21 @@ int main(int argc, char *argv[]) {
 
     int winW, winH, drwW, drwH;
     SDL_GetWindowSize(win, &winW, &winH);
+
+    int displayIndex = SDL_GetWindowDisplayIndex(win);
+    SDL_Rect displayRect;
+    SDL_GetDisplayUsableBounds(displayIndex, &displayRect);
+    int top, bottom, left, right;
+    SDL_GetWindowBordersSize(win, &top, &bottom, &left, &right);
+    int maxWidth = displayRect.w;
+    int maxHeight = displayRect.h - top;
+    winW = std::min(winW, maxWidth);
+    winH = std::min(winH, maxHeight);
+    SDL_SetWindowSize(win, winW, winH);
+    SDL_SetWindowPosition(win,
+        displayRect.x + ((displayRect.w - winW) / 2),
+        displayRect.y + ((displayRect.h + top - winH) / 2));
+
     rtData.windowSizeMsg.post(Vec2i(winW, winH));
     
     SDL_GL_GetDrawableSize(win, &drwW, &drwH);


### PR DESCRIPTION
I decided to implement #65 and got a little carried away. In addition to allowing Graphics.scale to go beyond 4x, now all resize methods are capped to the display size and attempt to keep the center of the window's position on the screen without the top leaving the screen. I also fixed a little wonkiness with Graphics.center on Windows resulting from the title bar not being included in the height calculations.

I tested this on macOS and Windows, but not Linux.

Fixes #65