### PR TITLE
Graphics.transition average FPS bugfix

### DIFF
--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -1083,14 +1083,7 @@ struct GraphicsPrivate {
         
         swapGLBuffer();
         
-        SDL_LockMutex(avgFPSLock);
-        if (avgFPSData.size() > 40)
-            avgFPSData.erase(avgFPSData.begin());
-        
-        double time = shState->runTime();
-        avgFPSData.push_back(time - last_avg_update);
-        last_avg_update = time;
-        SDL_UnlockMutex(avgFPSLock);
+        updateAvgFPS();
     }
     
     void checkSyncLock() {
@@ -1129,6 +1122,17 @@ struct GraphicsPrivate {
         if (!(force || multithreadedMode)) return;
         
         SDL_UnlockMutex(glResourceLock);
+    }
+
+    void updateAvgFPS() {
+        SDL_LockMutex(avgFPSLock);
+        if (avgFPSData.size() > 40)
+            avgFPSData.erase(avgFPSData.begin());
+        
+        double time = shState->runTime();
+        avgFPSData.push_back(time - last_avg_update);
+        last_avg_update = time;
+        SDL_UnlockMutex(avgFPSLock);
     }
 };
 
@@ -1309,6 +1313,8 @@ void Graphics::transition(int duration, const char *filename, int vague) {
         GLMeta::blitEnd();
         
         p->swapGLBuffer();
+        /* Call this manually, as redrawScreen() is not called during this loop. */
+        p->updateAvgFPS();
     }
     
     glState.blend.pop();

--- a/tests/graphics-transition/transition.rb
+++ b/tests/graphics-transition/transition.rb
@@ -1,0 +1,17 @@
+# Test script for mkxp-z Graphics.transition reported FPS bug fix.
+# Run via the "customScript" field in mkxp.json.
+
+puts 'No transition. Counter should be normal'
+normal_duration = 2
+Graphics.wait(normal_duration * Graphics.frame_rate)
+
+transition_duration = 10 # Default value used in RGSS
+num_transitions = 20
+puts 'Performing transitions. If the FPS counter notably dips, the bug is not fixed.'
+num_transitions.times do
+  Graphics.freeze
+  Graphics.transition(transition_duration)
+  Graphics.wait(transition_duration)
+end
+
+exit


### PR DESCRIPTION
Move average FPS update logic into new function updateAvgFPS()
Call this during Graphics.transition so that the FPS counter does not erroneously drop

Currently, the average FPS is only calculated when `redrawScreen()` is called. Any situations where the game is updating normally, but not calling that method, will result in an incorrect drop in the counter. This PR updates `Graphics.transition` to invoke this each iteration of the transition loop, which seems to correct the reported frame rate during a transition. One can test the difference by spamming the menu button during normal gameplay of a barebones RPG Maker project.

- Vanilla VXA (and probably VX and XP) will show no drop when spamming menu transitions
- mkxp-z will drop the more you do it; I can hit mid-20s when the norm is 60
- mkxp-z+this fix will maintain the same average FPS of 60

This does not impact the *actual* performance; rather, the bug is with the reported FPS.

I'm open to suggestions on other places this might need to be called. `Graphics.transition` is the most obvious one.