### PR TITLE
Improve Matching Text with RGSS

### DIFF
--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -1562,7 +1562,7 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
     if (p->font->getOutline())
     {
         SDL_Color co = outColor.toSDLColor();
-        co.a = 255;
+        co.a = 160;
         SDL_Surface *outline;
         /* set the next font render to render the outline */
         TTF_SetFontOutline(font, OUTLINE_SIZE);
@@ -1582,7 +1582,8 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
         TTF_SetFontOutline(font, 0);
     }
     
-    int alignX = rect.x;
+    // Offset x and y coordinates by -1 to match RGSS text position.
+    int alignX = rect.x - 1;
     
     switch (align)
     {
@@ -1599,10 +1600,11 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
             break;
     }
     
-    if (alignX < rect.x)
-        alignX = rect.x;
+    // Alignment is 1 pixel off if we do this.
+    //if (alignX < rect.x)
+        //alignX = rect.x;
     
-    int alignY = rect.y + (rect.h - rawTxtSurfH) / 2;
+    int alignY = (rect.y - 1) + (rect.h - rawTxtSurfH) / 2;
     
     float squeeze = (float) rect.w / txtSurf->w;
     

--- a/src/display/font.cpp
+++ b/src/display/font.cpp
@@ -202,10 +202,8 @@ _TTF_Font *SharedFontState::getFont(std::string family,
 		shState->fileSystem().openReadRaw(*ops, path, true);
 	}
 
-	// FIXME 0.9 is guesswork at this point
-//	float gamma = (96.0/45.0)*(5.0/14.0)*(size-5);
-//	font = TTF_OpenFontRW(ops, 1, gamma /** .90*/);
-	font = TTF_OpenFontRW(ops, 1, size* 0.90f);
+	//Setting font size at 56 dpi allows us to accurately translate pt to px.
+	font = TTF_OpenFontDPIRW(ops, 1, size, 56, 56);
 
 	if (!font)
 		throw Exception(Exception::SDLError, "%s", SDL_GetError());
@@ -230,7 +228,7 @@ _TTF_Font *SharedFontState::openBundled(int size)
 {
 	SDL_RWops *ops = openBundledFont();
 
-	return TTF_OpenFontRW(ops, 1, size);
+	return TTF_OpenFontDPIRW(ops, 1, size, 56, 56);
 }
 
 void SharedFontState::setDefaultFontFamily(const std::string &family) {
@@ -339,7 +337,7 @@ struct FontPrivate
 };
 
 std::string FontPrivate::defaultName     = "Arial";
-int         FontPrivate::defaultSize     = 22;
+int         FontPrivate::defaultSize     = 24;
 bool        FontPrivate::defaultBold     = false;
 bool        FontPrivate::defaultItalic   = false;
 bool        FontPrivate::defaultOutline  = false; /* Inited at runtime */


### PR DESCRIPTION
Refs #83 

This improves, but does not completely fix, the mismatched size text between the original RPG Maker implementation and mkxp-z. There are still instances when the size and alignment of text differs, but this fixes the most glaring issues.