### PR TITLE
Font and draw_text adjustments

### DIFF
--- a/macos/mkxp-z.xcodeproj/project.pbxproj
+++ b/macos/mkxp-z.xcodeproj/project.pbxproj
@@ -3090,6 +3090,7 @@
 					"$(DEPENDENCY_SEARCH_PATH)/include/AL",
 					"$(DEPENDENCY_SEARCH_PATH)/include/openssl",
 					"$(DEPENDENCY_SEARCH_PATH)/include/uchardet",
+					"$(DEPENDENCY_SEARCH_PATH)/include/freetype2",
 					"$(PROJECT_DIR)/Dependencies/Frameworks/ANGLE",
 				);
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3177,6 +3178,7 @@
 					"$(DEPENDENCY_SEARCH_PATH)/include/AL",
 					"$(DEPENDENCY_SEARCH_PATH)/include/openssl",
 					"$(DEPENDENCY_SEARCH_PATH)/include/uchardet",
+					"$(DEPENDENCY_SEARCH_PATH)/include/freetype2",
 					"$(PROJECT_DIR)/Dependencies/Frameworks/ANGLE",
 				);
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3263,6 +3265,7 @@
 					"$(DEPENDENCY_SEARCH_PATH)/include/AL",
 					"$(DEPENDENCY_SEARCH_PATH)/include/openssl",
 					"$(DEPENDENCY_SEARCH_PATH)/include/uchardet",
+					"$(DEPENDENCY_SEARCH_PATH)/include/freetype2",
 					"$(PROJECT_DIR)/Dependencies/Frameworks/ANGLE",
 				);
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3344,6 +3347,7 @@
 					"$(DEPENDENCY_SEARCH_PATH)/include/AL",
 					"$(DEPENDENCY_SEARCH_PATH)/include/openssl",
 					"$(DEPENDENCY_SEARCH_PATH)/include/uchardet",
+					"$(DEPENDENCY_SEARCH_PATH)/include/freetype2",
 					"$(PROJECT_DIR)/Dependencies/Frameworks/ANGLE",
 				);
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3555,6 +3559,7 @@
 					"$(DEPENDENCY_SEARCH_PATH)/include/AL",
 					"$(DEPENDENCY_SEARCH_PATH)/include/openssl",
 					"$(DEPENDENCY_SEARCH_PATH)/include/uchardet",
+					"$(DEPENDENCY_SEARCH_PATH)/include/freetype2",
 					"$(PROJECT_DIR)/Dependencies/Frameworks/ANGLE",
 				);
 				INFOPLIST_FILE = Info.plist;
@@ -3625,6 +3630,7 @@
 					"$(DEPENDENCY_SEARCH_PATH)/include/AL",
 					"$(DEPENDENCY_SEARCH_PATH)/include/openssl",
 					"$(DEPENDENCY_SEARCH_PATH)/include/uchardet",
+					"$(DEPENDENCY_SEARCH_PATH)/include/freetype2",
 					"$(PROJECT_DIR)/Dependencies/Frameworks/ANGLE",
 				);
 				INFOPLIST_FILE = Info.plist;

--- a/mkxp.json
+++ b/mkxp.json
@@ -419,6 +419,34 @@
     //     "Times New Roman>Liberation Serif",
     // ],
 
+    // RGSS preferentially uses a special table stored some fonts
+    // to determine the size of text.
+    // Historically, however, mkxp used a different method
+    // to determine the size that typically produced different
+    // results. Since this will cause rendering problems with
+    // games that were made for mkxp, this setting can be used
+    // to choose the method.
+    // 0: Defaults to 1 if rgssVersion is 1, 2 if rgssVersion is 2 or 3
+    // 1: The classic mkxp font size method. Recommended for Pokémon Essentials games.
+    // 2: RGSS's method. Recommended for RGSS games, including XP games
+    //    which we can't automatically distinguish from Pokémon Essentials games.
+    // (default: 0)
+    //
+    // "fontSizeMethod": 0,
+
+    // Scales the sizes of all fonts.
+    // If you think text tends to be too large or too small,
+    // try fiddling with this.
+    // For legacy reasons, this defaults to 0.9 when fontSizeMethod is set to 1.
+    // (default: 0.9 with fontSizeMethod 1, 1.0 otherwise)
+    // "fontScale": 1.0,
+
+    // Kerning adjusts the spacing between individual letters or characters.
+    // Enabling it generally looks nicer, but RGSS doesn't use it,
+    // so disabling it should make text appearance more accurate.
+    // (default: true)
+    // "fontKerning": true,
+
 
     // Because mkxp is usually distributed as a stand alone
     // build, no predefined load paths are initialized

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -190,6 +190,9 @@ void Config::read(int argc, char *argv[]) {
         {"RTP", json::array({})},
         {"patches", json::array({})},
         {"fontSub", json::array({})},
+        {"fontSizeMethod", 0},
+        {"fontScale", 0.0f},
+        {"fontKerning", true},
         {"rubyLoadpath", json::array({})},
         {"JITEnable", false},
         {"JITVerboseLevel", 0},
@@ -322,6 +325,9 @@ try { exp } catch (...) {}
     for (std::string & fontSub : fontSubs)
         std::transform(fontSub.begin(), fontSub.end(), fontSub.begin(),
             [](unsigned char c) { return std::tolower(c); });
+    SET_OPT(fontSizeMethod, integer);
+    SET_OPT(fontScale, number);
+    SET_OPT(fontKerning, boolean);
     fillStringVec(opts["rubyLoadpath"], rubyLoadpaths);
     
     auto &bnames = opts["bindingNames"].as_object();

--- a/src/config.h
+++ b/src/config.h
@@ -117,6 +117,9 @@ struct Config {
     std::vector<std::string> patches;
     
     std::vector<std::string> fontSubs;
+    int fontSizeMethod;
+    float fontScale;
+    bool fontKerning;
     
     std::vector<std::string> rubyLoadpaths;
 

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -2055,8 +2055,29 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
     const Color &fontColor = p->font->getColor();
     const Color &outColor = p->font->getOutColor();
     
+    // RGSS crops the the text slightly if there's an outline
+    int scaledOutlineSize = 0;
+    if (p->font->getOutline()) {
+        // Handle high-res for outline.
+        if (p->selfLores) {
+            scaledOutlineSize = OUTLINE_SIZE * width() / p->selfLores->width();
+        } else {
+            scaledOutlineSize = OUTLINE_SIZE;
+        }
+    }
+    int doubleOutlineSize = scaledOutlineSize * 2;
+    
     SDL_Color c = fontColor.toSDLColor();
-    c.a = 255;
+    int txtAlpha;
+    if(scaledOutlineSize)
+    {
+        c.a = 255;
+        txtAlpha = fontColor.alpha;
+    }
+    else
+    {
+        txtAlpha = 255;
+    }
     
     // Trim the text to only fill double the rect width
     int charLimit = 0;
@@ -2096,40 +2117,8 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
     
     p->ensureFormat(txtSurf, SDL_PIXELFORMAT_ABGR8888);
     
-    int rawTxtSurfH = txtSurf->h;
-    
     if (p->font->getShadow())
         applyShadow(txtSurf, *p->format, c);
-    
-    /* outline using TTF_Outline and blending it together with SDL_BlitSurface
-     * FIXME: outline is forced to have the same opacity as the font color */
-    if (p->font->getOutline())
-    {
-        SDL_Color co = outColor.toSDLColor();
-        co.a = 255;
-        SDL_Surface *outline;
-        // Handle high-res for outline.
-        int scaledOutlineSize = OUTLINE_SIZE;
-        if (p->selfLores) {
-            scaledOutlineSize = scaledOutlineSize * width() / p->selfLores->width();
-        }
-        /* set the next font render to render the outline */
-        TTF_SetFontOutline(font, scaledOutlineSize);
-        if (p->font->isSolid())
-            outline = TTF_RenderUTF8_Solid(font, str, co);
-        else
-            outline = TTF_RenderUTF8_Blended(font, str, co);
-        
-        p->ensureFormat(outline, SDL_PIXELFORMAT_ABGR8888);
-        SDL_Rect outRect = {scaledOutlineSize, scaledOutlineSize, txtSurf->w, txtSurf->h};
-        
-        SDL_SetSurfaceBlendMode(txtSurf, SDL_BLENDMODE_BLEND);
-        SDL_BlitSurface(txtSurf, NULL, outline, &outRect);
-        SDL_FreeSurface(txtSurf);
-        txtSurf = outline;
-        /* reset outline to 0 */
-        TTF_SetFontOutline(font, 0);
-    }
     
     int alignX = rect.x;
     
@@ -2140,18 +2129,20 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
             break;
             
         case Center :
-            alignX += (rect.w - txtSurf->w) / 2;
+            // Yes, half of the outline size.
+            alignX += (rect.w - (txtSurf->w + scaledOutlineSize)) / 2;
             break;
             
         case Right :
-            alignX += rect.w - txtSurf->w;
+            // I don't know why it's double the outline size, but it is.
+            alignX += rect.w - txtSurf->w - doubleOutlineSize;
             break;
     }
     
     if (alignX < rect.x)
         alignX = rect.x;
     
-    int alignY = rect.y + (rect.h - rawTxtSurfH) / 2;
+    int alignY = rect.y + ((rect.h - txtSurf->h) / 2) - scaledOutlineSize;
     
     alignY = std::max(alignY, rect.y);
     
@@ -2162,20 +2153,47 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
     
     squeeze = clamp(squeeze, squeezeLimit, 1.0f);
     
-    IntRect destRect(alignX, alignY, 0, 0);
-    destRect.w = std::min(rect.w, (int)(txtSurf->w * squeeze));
-    destRect.h = std::min(rect.h, txtSurf->h);
+    /* outline using TTF_Outline and blending it together with SDL_BlitSurface
+     * FIXME: RGSS's "outline" includes a complete set of text behind the regular text
+     * which loses opacity at a different rate than you'd expect.
+     * I gave up on trying to figure out the algorithm, so our transparent text will
+     * generally be paler than it should be. */
+    if (scaledOutlineSize)
+    {
+        SDL_Color co = outColor.toSDLColor();
+        SDL_Surface *outline;
+        /* set the next font render to render the outline */
+        TTF_SetFontOutline(font, scaledOutlineSize);
+        if (p->font->isSolid())
+            outline = TTF_RenderUTF8_Solid(font, str, co);
+        else
+            outline = TTF_RenderUTF8_Blended(font, str, co);
+        
+        p->ensureFormat(outline, SDL_PIXELFORMAT_ABGR8888);
+        SDL_Rect inRect = {scaledOutlineSize, scaledOutlineSize,
+                           (int)(rect.w / squeeze) - doubleOutlineSize, rect.h - doubleOutlineSize};
+        SDL_Rect outRect = {doubleOutlineSize, doubleOutlineSize, txtSurf->w, txtSurf->h};
+        
+        SDL_SetSurfaceBlendMode(txtSurf, SDL_BLENDMODE_BLEND);
+        SDL_BlitSurface(txtSurf, &inRect, outline, &outRect);
+        SDL_FreeSurface(txtSurf);
+        txtSurf = outline;
+        /* reset outline to 0 */
+        TTF_SetFontOutline(font, 0);
+    }
+    
+    IntRect destRect(alignX, alignY,
+                    std::min(rect.w, (int)(txtSurf->w * squeeze)),
+                    std::min(rect.h, txtSurf->h));
     
     destRect.w = std::min(destRect.w, width() - destRect.x);
     destRect.h = std::min(destRect.h, height() - destRect.y);
     
-    IntRect sourceRect;
-    sourceRect.w = destRect.w / squeeze;
-    sourceRect.h = destRect.h;
+    IntRect sourceRect(scaledOutlineSize, scaledOutlineSize, destRect.w / squeeze, destRect.h);
     
     Bitmap txtBitmap(txtSurf, nullptr, true);
     bool smooth = squeeze != 1.0f;
-    stretchBlt(destRect, txtBitmap, sourceRect, fontColor.alpha, smooth);
+    stretchBlt(destRect, txtBitmap, sourceRect, txtAlpha, smooth);
 }
 
 /* http://www.lemoda.net/c/utf8-to-ucs2/index.html */

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -2058,6 +2058,15 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
     SDL_Color c = fontColor.toSDLColor();
     c.a = 255;
     
+    // Trim the text to only fill double the rect width
+    int charLimit = 0;
+    float squeezeLimit = 0.5f;
+    if (TTF_MeasureUTF8(font, str, std::min(width() - rect.x, rect.w) / squeezeLimit, &charLimit, nullptr) == 0)
+    {
+        fixed = fixed.substr(0, charLimit + 1);
+        str = fixed.c_str();
+    }
+    
     SDL_Surface *txtSurf;
     
     if (p->font->isSolid())
@@ -2131,7 +2140,7 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
      * have made the rects bigger to compensate, so we should probably match it */
     float squeeze = (float) rect.w / txtSurf->w;
     
-    squeeze = clamp(squeeze, 0.5f, 1.0f);
+    squeeze = clamp(squeeze, squeezeLimit, 1.0f);
     
     IntRect destRect(alignX, alignY, 0, 0);
     destRect.w = std::min(rect.w, (int)(txtSurf->w * squeeze));

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -2124,6 +2124,8 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
     
     int alignY = rect.y + (rect.h - rawTxtSurfH) / 2;
     
+    alignY = std::max(alignY, rect.y);
+    
     float squeeze = (float) rect.w / txtSurf->w;
     
     if (squeeze > 1)

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -2126,10 +2126,12 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
     
     alignY = std::max(alignY, rect.y);
     
+    /* FIXME: RGSS begins squeezing the text before it fills the rect.
+     * While this is extremely undesirable, a number of games will understandably
+     * have made the rects bigger to compensate, so we should probably match it */
     float squeeze = (float) rect.w / txtSurf->w;
     
-    if (squeeze > 1)
-        squeeze = 1;
+    squeeze = clamp(squeeze, 0.5f, 1.0f);
     
     IntRect destRect(alignX, alignY, 0, 0);
     destRect.w = std::min(rect.w, (int)(txtSurf->w * squeeze));

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -2015,6 +2015,11 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
     GUARD_MEGA;
     GUARD_ANIMATED;
     
+    // RGSS doesn't let you draw text backwards
+    if (rect.w <= 0 || rect.h <= 0 || rect.x >= width() || rect.y >= height() ||
+        rect.w < -rect.x || rect.h < -rect.y)
+        return;
+    
     if (hasHires()) {
         Font &loresFont = getFont();
         Font &hiresFont = p->selfHires->getFont();

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -2163,9 +2163,9 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
                 /* Step 2: Compute the opacity of the outline that would have been drawn behind the text.
                  * In RGSS, there's a 1 pixel wide region at the edge of the text that only has
                  * 2 layers of outline instead of the 4 layers that's behind most of the text,
-                 * which noticeably affects the appearance of the text. We can't easily replicate this
-                 * in a way that looks nice in hires mode, however, so as a compromise we'll use the average
-                 * of the 2-layer and 4-layer alphas. */
+                 * which combined with the outlines having less opaque corners from how they're drawn
+                 * slightly affects the appearance of the text. We can't replicate this in a way that
+                 * looks nice in hires mode, however, this will have to be good enough. */
                 uint8_t out_alpha_full = co.a; // compute outline alpha - 4 layers
                 for (int i = 0; i < 2; ++i) {
                     int co1 = out_alpha * 255;
@@ -2176,11 +2176,10 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
                      * RGSS seems to not round, but our blit shader seemingly does. */
                     //out_alpha_full = (fa + 128 + ((fa + 128) >> 8)) >> 8;
                 }
-                out_alpha = (out_alpha + out_alpha_full) / 2;
                 
-                /* Step 3: Calculate the text color using out_alpha in place of co.a. */
+                /* Step 3: Calculate the text color using out_alpha_full in place of co.a. */
                 int co1 = c.a * 255;
-                int co2 = out_alpha * (255 - c.a);
+                int co2 = out_alpha_full * (255 - c.a);
                 int fa = co1 + co2;
                 
                 float faInv = 1.0f / fa;

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -2203,7 +2203,15 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
     // rect dimensions.
     // Also use it to determine position, because freetype sometimes treats the last character as
     // being a pixel wider than it should be, and which textSize is currently set to compensate for.
-    int alignmentWidth = textSize(str).w;
+    int alignmentWidth, alignmentHeight;
+    {
+        const IntRect &text_size = textSize(str);
+        alignmentWidth = text_size.w;
+        alignmentHeight = text_size.h;
+        
+        if (!alignmentWidth)
+            return;
+    }
     
     // Trim the text to only fill double the rect width
     int charLimit = 0;
@@ -2272,7 +2280,7 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
     if (alignX < rect.x)
         alignX = rect.x;
     
-    int alignY = rect.y + ((rect.h - txtSurf->h) / 2) - scaledOutlineSize;
+    int alignY = rect.y + ((rect.h - alignmentHeight) / 2) - scaledOutlineSize;
     
     alignY = std::max(alignY, rect.y);
     
@@ -2415,6 +2423,15 @@ IntRect Bitmap::textSize(const char *str)
      * as width yields better results */
     if (p->font->getItalic() && *endPtr == '\0')
         TTF_GlyphMetrics(sdlFont, ucs2, 0, 0, 0, 0, &w);
+    
+    if(!w) {
+        h = 0;
+    } else {
+        /* RGSS normalizes the reported heights.
+         * Note that this may result in the bottoms
+         * of some characters being cut off. */
+         h = TTF_FontHeight(sdlFont);
+    }
     
     return IntRect(0, 0, w, h);
 }

--- a/src/display/font.cpp
+++ b/src/display/font.cpp
@@ -158,9 +158,9 @@ void SharedFontState::initFontSetCB(SDL_RWops &ops,
 
 	FontSet &set = p->sets[family];
 
-	if (style == "Regular")
+	if (style == "Regular" && set.regular.empty())
 		set.regular = filename;
-	else
+	else if (style != "Regular" && set.other.empty())
 		set.other = filename;
 }
 

--- a/src/display/font.cpp
+++ b/src/display/font.cpp
@@ -41,6 +41,10 @@
 
 #include <SDL_ttf.h>
 
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#include FT_TRUETYPE_TABLES_H
+
 #ifndef MKXPZ_BUILD_XCODE
 #ifndef MKXPZ_CJK_FONT
 #include "liberation.ttf.xxd"
@@ -164,6 +168,259 @@ void SharedFontState::initFontSetCB(SDL_RWops &ops,
 		set.other = filename;
 }
 
+/* The following code was taken from Wine to emulate
+ * Windows's font size selection behavior. */
+ 
+/* We're not currently using yMax and yMin for anything,
+ * but it could be useful later. */
+typedef struct {
+	TTF_Font *font;
+	int ppem;
+	short yMax;
+	short yMin;
+} Font_Container;
+
+#define BYTE uint8_t
+#define WORD uint16_t
+#define DWORD uint32_t
+#define UINT unsigned int
+#define SHORT short
+#define USHORT unsigned short
+#define GDI_ERROR ~0u
+
+#define MS_MAKE_TAG(ch0, ch1, ch2, ch3)                                                 \
+                    ((uint32_t)(uint8_t)(ch0) | ((uint32_t)(uint8_t)(ch1) << 8) |       \
+                    ((uint32_t)(uint8_t)(ch2) << 16) | ((uint32_t)(uint8_t)(ch3) << 24))
+#define MS_VDMX_TAG MS_MAKE_TAG('V', 'D', 'M', 'X')
+
+/* Wine's code suggests the tables are stored in big endian format. */
+#define RTLUSHORTBYTESWAP(x) (uint16_t)((x >> 8) | (x << 8))
+#define RTLULONGBYTESWAP(x) (((uint32_t)RTLUSHORTBYTESWAP((uint16_t)x) << 16) | RTLUSHORTBYTESWAP((uint16_t)(x >> 16)))
+
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+#define GET_BE_WORD(x) (x)
+#else
+#define GET_BE_WORD(x) RTLUSHORTBYTESWAP(x)
+#endif
+
+static unsigned int freetype_get_font_data( Font_Container *font, uint32_t table,
+                                            unsigned int offset, void *buf, unsigned int cbData)
+{
+	FT_Face ft_face = *(reinterpret_cast<FT_Face *>( font->font ));
+	FT_ULong len;
+	FT_Error err;
+
+	if (!FT_IS_SFNT(ft_face)) return GDI_ERROR;
+
+	if(!buf)
+		len = 0;
+	else
+		len = cbData;
+
+	/* MS tags differ in endianness from FT ones */
+	table = RTLULONGBYTESWAP( table );
+
+	/* make sure value of len is the value freetype says it needs */
+	if (buf && len)
+	{
+		FT_ULong needed = 0;
+		err = FT_Load_Sfnt_Table(ft_face, table, offset, NULL, &needed);
+		if(!err && needed < len)
+			len = needed;
+	}
+	err = FT_Load_Sfnt_Table(ft_face, table, offset, (FT_Byte*)buf, &len);
+	if (err) /* Can't find table */
+		return GDI_ERROR;
+	return (int)len;
+}
+
+typedef struct {
+	uint16_t version;
+	uint16_t numRecs;
+	uint16_t numRatios;
+} VDMX_Header;
+
+typedef struct {
+	uint8_t bCharSet;
+	uint8_t xRatio;
+	uint8_t yStartRatio;
+	uint8_t yEndRatio;
+} Ratios;
+
+typedef struct {
+	uint16_t recs;
+	uint8_t startsz;
+	uint8_t endsz;
+} VDMX_group;
+
+typedef struct {
+	uint16_t yPelHeight;
+	uint16_t yMax;
+	uint16_t yMin;
+} VDMX_vTable;
+
+static int load_VDMX(Font_Container *font, int height)
+{
+	VDMX_Header hdr;
+	VDMX_group group;
+	uint8_t devXRatio, devYRatio;
+	unsigned short numRatios;
+	unsigned int result, offset = -1;
+	int i, ppem = 0;
+
+	result = freetype_get_font_data(font, MS_VDMX_TAG, 0, &hdr, sizeof(hdr));
+
+	if(result == GDI_ERROR) /* no vdmx table present, use linear scaling */
+		return ppem;
+
+	/* FIXME: need the real device aspect ratio */
+	devXRatio = 1;
+	devYRatio = 1;
+
+	numRatios = GET_BE_WORD(hdr.numRatios);
+
+	for(i = 0; i < numRatios; i++) {
+		Ratios ratio;
+
+		offset = sizeof(hdr) + (i * sizeof(Ratios));
+		freetype_get_font_data(font, MS_VDMX_TAG, offset, &ratio, sizeof(Ratios));
+		offset = -1;
+
+		if (!ratio.bCharSet)
+			continue;
+
+		if((ratio.xRatio == 0 &&
+			ratio.yStartRatio == 0 &&
+			ratio.yEndRatio == 0) ||
+		   (devXRatio == ratio.xRatio &&
+			devYRatio >= ratio.yStartRatio &&
+			devYRatio <= ratio.yEndRatio))
+		{
+			uint16_t group_offset;
+
+			offset = sizeof(hdr) + numRatios * sizeof(ratio) + i * sizeof(group_offset);
+			freetype_get_font_data(font, MS_VDMX_TAG, offset, &group_offset, sizeof(group_offset));
+			offset = GET_BE_WORD(group_offset);
+			break;
+		}
+	}
+
+	if(offset == -1) return 0;
+
+	if(freetype_get_font_data(font, MS_VDMX_TAG, offset, &group, sizeof(group)) != GDI_ERROR) {
+		uint16_t recs;
+		std::vector<VDMX_vTable> vTable;
+
+		recs = GET_BE_WORD(group.recs);
+
+		vTable.resize(recs);
+		result = freetype_get_font_data(font, MS_VDMX_TAG, offset + sizeof(group), &vTable[0], recs * sizeof(VDMX_vTable));
+		if(result == GDI_ERROR) /* Failed to retrieve vTable */
+			return 0;
+
+		for(i = 0; i < recs; i++) {
+			VDMX_vTable &entry = vTable[i];
+			short yMax = GET_BE_WORD(entry.yMax);
+			short yMin = GET_BE_WORD(entry.yMin);
+			ppem = GET_BE_WORD(entry.yPelHeight);
+
+			if(yMax + -yMin == height) {
+				font->yMax = yMax;
+				font->yMin = yMin;
+				break;
+			}
+			if(yMax + -yMin > height) {
+				if(--i < 0) {
+					ppem = 0;
+					return 0; /* failed */
+				}
+				VDMX_vTable &entry = vTable[i];
+				font->yMax = GET_BE_WORD(entry.yMax);
+				font->yMin = GET_BE_WORD(entry.yMin);
+				ppem = GET_BE_WORD(entry.yPelHeight);
+				break;
+			}
+		}
+		if(!font->yMax) /* ppem not found for height */
+			ppem = 0;
+	}
+
+	return ppem;
+}
+
+/* Some fonts have large usWinDescent values, as a result of storing signed short
+   in unsigned field. That's probably caused by sTypoDescent vs usWinDescent confusion in
+   some font generation tools. */
+static inline USHORT get_fixed_windescent(USHORT windescent)
+{
+    return abs((SHORT)windescent);
+}
+
+static int calc_ppem_for_height(Font_Container *font, int height)
+{
+	FT_Face ft_face = *(reinterpret_cast<FT_Face *>( font->font ));
+	TT_OS2 *pOS2;
+	TT_HoriHeader *pHori;
+
+	int ppem;
+	const int MAX_PPEM = (1 << 16) - 1;
+
+	pOS2 = (TT_OS2 *)FT_Get_Sfnt_Table(ft_face, FT_SFNT_OS2);
+	pHori = (TT_HoriHeader *)FT_Get_Sfnt_Table(ft_face, FT_SFNT_HHEA);
+
+	if(height == 0)
+		height = 16;
+
+	/* Calc. height of EM square:
+	 *
+	 * For +ve lfHeight we have
+	 * lfHeight = (winAscent + winDescent) * ppem / units_per_em
+	 * Re-arranging gives:
+	 * ppem = units_per_em * lfheight / (winAscent + winDescent)
+	 *
+	 * For -ve lfHeight we have
+	 * |lfHeight| = ppem
+	 * [i.e. |lfHeight| = (winAscent + winDescent - il) * ppem / units_per_em
+	 * with il = winAscent + winDescent - units_per_em]
+	 *
+	 */
+
+	if(height > 0) {
+		USHORT windescent = get_fixed_windescent(pOS2->usWinDescent);
+		int units;
+
+		if(pOS2->usWinAscent + windescent == 0)
+		{
+			font->yMax = pHori->Ascender;
+			font->yMin = pHori->Descender;
+			units = pHori->Ascender - pHori->Descender;
+		} else {
+			font->yMax = pOS2->usWinAscent;
+			font->yMin = -windescent;
+			units = pOS2->usWinAscent + windescent;
+		}
+		ppem = (int)FT_MulDiv(ft_face->units_per_EM, height, units);
+
+		/* If rounding ends up getting a font exceeding height, choose a smaller ppem */
+		if(ppem > 1 && FT_MulDiv(units, ppem, ft_face->units_per_EM) > height)
+			--ppem;
+
+		if(ppem > MAX_PPEM) {
+			//WARN("Ignoring too large height %d, ppem %d\n", height, ppem);
+			ppem = 1;
+		}
+	}
+	else if(height >= -MAX_PPEM)
+		ppem = -height;
+	else {
+		//WARN("Ignoring too large height %d\n", height);
+		ppem = 1;
+	}
+
+	return ppem;
+}
+/* /wine */
+
 _TTF_Font *SharedFontState::getFont(std::string family,
                                     int size)
 {
@@ -217,14 +474,42 @@ _TTF_Font *SharedFontState::getFont(std::string family,
 		}
 	}
 
-	// FIXME 0.9 is guesswork at this point
-//	float gamma = (96.0/45.0)*(5.0/14.0)*(size-5);
-//	font = TTF_OpenFontRW(ops, 1, gamma /** .90*/);
-	font = TTF_OpenFontRW(ops, 1, size* 0.90f);
+	/* Try to compute the size the same way Windows does. */
+	font = TTF_OpenFontRW(ops, 1, 0);
 
 	if (!font)
 		throw Exception(Exception::SDLError, "%s", SDL_GetError());
 
+	/* Dirty hack to get the FT_Face.
+	 * SDL_ttf will probably never move it from the beginning of the struct. */
+	FT_Face face= *(reinterpret_cast<FT_Face *>( font ));
+	/* This is should always be true, but we may as well check... */
+	if (FT_IS_SCALABLE( face ))
+	{
+		Font_Container c = { 0 };
+		c.font = font;
+		c.ppem = load_VDMX(&c, size);
+		if (!c.ppem)
+		{
+			c.ppem = calc_ppem_for_height( &c, size );
+		}
+		if (TTF_SetFontSize(font, c.ppem))
+		{
+			TTF_CloseFont(font);
+			throw Exception(Exception::SDLError, "%s", SDL_GetError());
+		}
+	} else {
+		/* Someone must have renamed a non-scalable font file to ttf or otf.
+		 * Wine has a scaling setup for these, but I'll just leave it alone for now. */
+		if (TTF_SetFontSize(font, size))
+		{
+			TTF_CloseFont(font);
+			throw Exception(Exception::SDLError, "%s", SDL_GetError());
+		}
+	}
+	/* RGSS doesn't use font hinting */
+	TTF_SetFontHinting(font, TTF_HINTING_NONE);
+	
 	p->pool.insert(key, font);
 
 	return font;

--- a/src/display/font.cpp
+++ b/src/display/font.cpp
@@ -209,7 +209,12 @@ _TTF_Font *SharedFontState::getFont(std::string family,
 		                 ? req.regular.c_str() : req.other.c_str();
 
 		ops = SDL_AllocRW();
-		shState->fileSystem().openReadRaw(*ops, path, true);
+		try{
+			shState->fileSystem().openReadRaw(*ops, path, true);
+		} catch (const Exception &e) {
+			SDL_FreeRW(ops);
+			throw e;
+		}
 	}
 
 	// FIXME 0.9 is guesswork at this point

--- a/src/display/font.cpp
+++ b/src/display/font.cpp
@@ -505,6 +505,7 @@ void Font::initDefaults(const SharedFontState &sfs)
 	default:
 	case 3 :
 		names.push_back("VL Gothic");
+		FontPrivate::defaultSize = 24;
 	}
 
 	setDefaultName(names, sfs);

--- a/src/display/font.h
+++ b/src/display/font.h
@@ -48,7 +48,7 @@ public:
 	                   const std::string &filename);
 
 	_TTF_Font *getFont(std::string family,
-	                   int size, int outline_size = 0);
+	                   int size, float hiresMult, int outline_size = 0);
 
 	bool fontPresent(std::string family) const;
 
@@ -78,6 +78,7 @@ public:
 
 	int getSize() const;
 	void setSize(int value, bool checkIllegal=true);
+	void setHiresMult(float value);
 
 	DECL_ATTR( Bold,     bool   )
 	DECL_ATTR( Italic,   bool   )

--- a/src/display/font.h
+++ b/src/display/font.h
@@ -48,7 +48,7 @@ public:
 	                   const std::string &filename);
 
 	_TTF_Font *getFont(std::string family,
-	                   int size);
+	                   int size, int outline_size = 0);
 
 	bool fontPresent(std::string family) const;
 
@@ -116,7 +116,7 @@ public:
 	static void initDefaults(const SharedFontState &sfs);
 
 	/* internal */
-	_TTF_Font *getSdlFont();
+	_TTF_Font *getSdlFont(int outline_size);
 
 private:
 	FontPrivate *p;


### PR DESCRIPTION
Brute forcing the font size calculation to get the proper dpi, although the kerning/letter spacing still isn't identical to RPGM.

Removing the leftmost column of pixels from draw_text calls is weird, but it's what RPGM does and wasn't hard to implement.

~~Some fonts that look smooth in RPGM look kind of ugly in mkxp-z. I think upgrading SDL_ttf to at least 2.20.0 for TTF_RenderUTF8_LCD would probably fix that.~~