### PR TITLE
Fix precision issues in vertex shaders

### DIFF
--- a/shader/common.h
+++ b/shader/common.h
@@ -1,6 +1,9 @@
 #ifdef GLSLES
 
+#ifdef FRAGMENT_SHADER
+/* Only the fragment shader has no default float precision */
 precision mediump float;
+#endif
 
 #else
 

--- a/shader/lanczos3.frag
+++ b/shader/lanczos3.frag
@@ -2,6 +2,7 @@
 // Copyright 2020 Lilian Gimenez (Sentmoraap).
 // MIT license.
 
+precision highp float;
 uniform sampler2D texture;
 uniform vec2 sourceSize;
 uniform vec2 texSizeInv;


### PR DESCRIPTION
As described in this commit, https://github.com/mkxp-z/mkxp-z/commit/359ccd7a0ce98ccf9aa79e7d7ea6734db3f04721 fixed the Lanczos3 shader on MacOS. However, as `common.h` applies to *all* shaders defined by mkxp-z, this had unintended side effects.

On my end, this gave a flickering effect of the last vertical row of pixels for each tile when scrolling horizontally, but only on Vulkan on Windows. Another user has reported a similar effect with the axes swapped on the PlayStation Classic. This was confirmed to exist in the latest mkxp-z dev branch on GitHub but *not* in the latest commit found on GitLab (https://github.com/mkxp-z/mkxp-z/commit/58de823d41f44a98df42fdd14315ae0e59fdce77). I confirmed this was also true with the visual bugs I saw. I bisected until I reached the commit above.

There may be other unknown issues that had been caused by this change as well, so I think it's best to simply put `common.h` back to the way it was. I added the highp declaration to `lanczos3.frag` so that it can compile nicely without affecting every other shader in the application.