### PR TITLE
Enable transparent blitting from megatextures.

### DIFF
--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -2000,6 +2000,8 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
         int rectHeight = rect.h * p->selfHires->height() / height();
 
         p->selfHires->drawText(IntRect(rectX, rectY, rectWidth, rectHeight), str, align);
+
+        return;
     }
 
     std::string fixed = fixupString(str);

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -1086,7 +1086,16 @@ void Bitmap::stretchBlt(IntRect destRect,
                         throw Exception(Exception::SDLError, "Error creating temporary surface for blitting: %s",
                                         SDL_GetError());
                     
-                    error = SDL_BlitScaled(srcSurf, &srcRect, blitTemp, 0);
+                    if (smooth)
+                    {
+                        error = SDL_SoftStretchLinear(srcSurf, &srcRect, blitTemp, 0);
+                        smooth = false;
+                    }
+                    else
+                    {
+                        SDL_Rect tmpRect = {0, 0, blitTemp->w, blitTemp->h};
+                        error = SDL_LowerBlitScaled(srcSurf, &srcRect, blitTemp, &tmpRect);
+                    }
                 }
                 else
                 {
@@ -1099,7 +1108,8 @@ void Bitmap::stretchBlt(IntRect destRect,
                         throw Exception(Exception::SDLError, "Error creating temporary surface for blitting: %s",
                                         SDL_GetError());
                     
-                    error = SDL_BlitSurface(srcSurf, &srcRect, blitTemp, 0);
+                    SDL_Rect tmpRect = {0, 0, blitTemp->w, blitTemp->h};
+                    error = SDL_LowerBlit(srcSurf, &srcRect, blitTemp, &tmpRect);
                 }
                 
                 if (error)

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -925,7 +925,7 @@ void Bitmap::blt(int x, int y,
     if (source.isDisposed())
         return;
     
-    stretchBlt(IntRect(x, y, rect.w, rect.h),
+    stretchBlt(IntRect(x, y, abs(rect.w), abs(rect.h)),
                source, rect, opacity);
 }
 

--- a/src/display/bitmap.h
+++ b/src/display/bitmap.h
@@ -42,7 +42,7 @@ public:
 	Bitmap(int width, int height, bool isHires = false);
 	Bitmap(void *pixeldata, int width, int height);
 	Bitmap(TEXFBO &other);
-	Bitmap(SDL_Surface *imgSurf, SDL_Surface *imgSurfHires);
+	Bitmap(SDL_Surface *imgSurf, SDL_Surface *imgSurfHires, bool forceMega = false);
 
 	/* Clone constructor */
     
@@ -50,7 +50,7 @@ public:
 	Bitmap(const Bitmap &other, int frame = -2);
 	~Bitmap();
 
-	void initFromSurface(SDL_Surface *imgSurf, Bitmap *hiresBitmap, bool freeSurface);
+	void initFromSurface(SDL_Surface *imgSurf, Bitmap *hiresBitmap, bool forceMega = false);
 
 	int width()  const;
 	int height() const;

--- a/src/display/bitmap.h
+++ b/src/display/bitmap.h
@@ -68,7 +68,7 @@ public:
 
 	void stretchBlt(IntRect destRect,
 	                const Bitmap &source, IntRect sourceRect,
-	                int opacity = 255);
+	                int opacity = 255, bool smooth = false);
 
 	void fillRect(int x, int y,
 	              int width, int height,


### PR DESCRIPTION
It turns out transparency didn't work with subImageFix on, either, it just wan't set to crash there.