### PR TITLE
Make the Windows resource dir customisable at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 mkxp
 xxd+
 
+/res
+
 /build
 /builddir
 

--- a/meson.build
+++ b/meson.build
@@ -125,10 +125,10 @@ global_include_dirs += include_directories('src', 'binding')
 rpath = ''
 
 if host_system == 'windows'
-    windows_resource_directory = get_option('windows_resource_directory')
-    subdir(windows_resource_directory)
+    windows_resource_directory = '../' + get_option('windows_resource_directory')
+    subdir('windows')
     global_sources += windows_resources
-    global_include_dirs += include_directories(windows_resource_directory)
+    global_include_dirs += include_directories('windows')
 else
     subdir('linux')
     rpath = '$ORIGIN/lib'

--- a/meson.build
+++ b/meson.build
@@ -125,9 +125,10 @@ global_include_dirs += include_directories('src', 'binding')
 rpath = ''
 
 if host_system == 'windows'
-    subdir('windows')
+    windows_resource_directory = get_option('windows_resource_directory')
+    subdir(windows_resource_directory)
     global_sources += windows_resources
-    global_include_dirs += include_directories('windows')
+    global_include_dirs += include_directories(windows_resource_directory)
 else
     subdir('linux')
     rpath = '$ORIGIN/lib'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -11,6 +11,8 @@ option('use_miniffi', type: 'boolean', value: true, description: 'Enable MiniFFI
 option('enable-https', type: 'boolean', value: true, description: 'Support HTTPS for get/post requests. Requires OpenSSL.')
 option('workdir_current', type: 'boolean', value: false, description: 'Keep current directory on startup')
 
+option('windows_resource_directory', type: 'string', value: 'windows', description: 'Path to Windows EXE resource directory')
+
 option('static_executable', type: 'boolean', value: true, description: 'Build a static executable (Windows-only)')
 option('appimagekit_path', type: 'string', value: '', description: 'Path to AppImageTool, used for building AppImages')
 option('appimage', type: 'boolean', value: false, description: 'Whether to install to an AppImage or just copy everything')

--- a/windows/meson.build
+++ b/windows/meson.build
@@ -1,10 +1,10 @@
 win = import('windows')
 
 res = files(
-'resource.h',
-'icon.ico',
-'mkxpz.manifest',
-'resource.rc'
+windows_resource_directory + '/resource.h',
+windows_resource_directory + '/icon.ico',
+windows_resource_directory + '/mkxpz.manifest',
+windows_resource_directory + '/resource.rc'
 )
 
-windows_resources = win.compile_resources('resource.rc', depend_files: res)
+windows_resources = win.compile_resources(windows_resource_directory + '/resource.rc', depend_files: res)


### PR DESCRIPTION
Ported from original mkxp-zr commit by @rainefall, with modifications by me to support a resources dir outside of the repo dir.