### PR TITLE
Compiler Flags: `-Ofast` and `-flto=full`

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -12,8 +12,8 @@ LIBDIR := $(BUILD_PREFIX)/lib
 INCLUDEDIR := $(BUILD_PREFIX)/include
 DOWNLOADS := ${PWD}/downloads/$(ARCH)
 NPROC := $(shell nproc)
-CFLAGS := -I$(INCLUDEDIR) -flax-vector-conversions -O3
-LDFLAGS := -L$(LIBDIR)
+CFLAGS := -I$(INCLUDEDIR) -Ofast -flax-vector-conversions
+LDFLAGS := -L$(LIBDIR) -Wl,-Ofast,-flto=full
 CC      := gcc
 PKG_CONFIG_LIBDIR := $(BUILD_PREFIX)/lib/pkgconfig
 GIT := git
@@ -321,8 +321,8 @@ $(LIBDIR)/libruby.so.3.1: $(DOWNLOADS)/ruby/Makefile
 $(DOWNLOADS)/ruby/Makefile: $(DOWNLOADS)/ruby/configure
 	cd $(DOWNLOADS)/ruby; \
 	export $(CONFIGURE_ENV); \
-	export CFLAGS="-flto $$CFLAGS"; \
-	export LDFLAGS="-flto $$LDFLAGS"; \
+	export CFLAGS="$$CFLAGS"; \
+	export LDFLAGS="$$LDFLAGS"; \
 	./configure $(CONFIGURE_ARGS) $(RUBY_CONFIGURE_ARGS) $(RUBY_FLAGS)
 
 $(DOWNLOADS)/ruby/configure: $(DOWNLOADS)/ruby/configure.ac

--- a/meson.build
+++ b/meson.build
@@ -113,7 +113,7 @@ if get_option('static_executable') == true
     build_static = true
 endif
 
-global_args += '-DMKXPZ_INIT_GL_LATER'
+global_args += '-DMKXPZ_INIT_GL_LATER -Ofast'
 
 subdir('src')
 subdir('binding')

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -14,8 +14,8 @@ BINDIR := $(BUILD_PREFIX)/bin
 INCLUDEDIR := $(BUILD_PREFIX)/include
 DOWNLOADS := ${PWD}/downloads/$(ARCH)
 NPROC := $(shell nproc)
-CFLAGS := -I$(INCLUDEDIR) -O3
-LDFLAGS := -L$(LIBDIR)
+CFLAGS := -I$(INCLUDEDIR) -Ofast
+LDFLAGS := -L$(LIBDIR) -Wl,-Ofast,-flto=full
 CC      := gcc
 PKG_CONFIG_LIBDIR := $(BUILD_PREFIX)/lib/pkgconfig
 GIT := git
@@ -309,8 +309,8 @@ $(BINDIR)/$(RB_PREFIX)-ruby310.dll: $(DOWNLOADS)/ruby/Makefile
 $(DOWNLOADS)/ruby/Makefile: $(DOWNLOADS)/ruby/configure
 	cd $(DOWNLOADS)/ruby; \
 	export $(CONFIGURE_ENV); \
-	export CFLAGS="-flto $$CFLAGS"; \
-	export LDFLAGS="-flto $$LDFLAGS"; \
+	export CFLAGS="$$CFLAGS"; \
+	export LDFLAGS="$$LDFLAGS"; \
 	./configure $(CONFIGURE_ARGS) $(RUBY_CONFIGURE_ARGS) $(RUBY_FLAGS)
 
 $(DOWNLOADS)/ruby/configure: $(DOWNLOADS)/ruby/configure.ac


### PR DESCRIPTION
Replace ``-O3`` with ``-Ofast``
Stop using ``-flto`` only for Ruby and use ``flto=full`` for everything