### PR TITLE
Bump OpenSSL on macOS to v3.0.12

### DIFF
--- a/macos/Dependencies/common.make
+++ b/macos/Dependencies/common.make
@@ -298,7 +298,7 @@ $(DOWNLOADS)/openssl/Makefile: $(DOWNLOADS)/openssl/Configure
 	--openssldir="$(BUILD_PREFIX)"
 
 $(DOWNLOADS)/openssl/Configure:
-	$(CLONE) $(GITHUB)/openssl/openssl $(DOWNLOADS)/openssl --single-branch --branch OpenSSL_1_1_1i --depth 1
+	$(CLONE) $(GITHUB)/openssl/openssl $(DOWNLOADS)/openssl --single-branch --branch openssl-3.0.12 --depth 1
 
 # Standard ruby
 ruby: init_dirs openssl $(LIBDIR)/libruby.3.1.dylib


### PR DESCRIPTION
Refs https://github.com/mkxp-z/mkxp-z/issues/46