### PR TITLE
Lanczos3/bicubic shaders: Only set default precision on GLES

### DIFF
--- a/shader/bicubic.frag
+++ b/shader/bicubic.frag
@@ -3,7 +3,10 @@
 // mkxp-z modifications Copyright 2022-2023 Splendide Imaginarius.
 // MIT license.
 
-precision highp float;
+#ifdef GLSLES
+	precision highp float;
+#endif
+
 uniform sampler2D texture;
 uniform vec2 sourceSize;
 uniform vec2 texSizeInv;

--- a/shader/lanczos3.frag
+++ b/shader/lanczos3.frag
@@ -3,7 +3,10 @@
 // mkxp-z modifications Copyright 2022-2023 Splendide Imaginarius.
 // MIT license.
 
-precision highp float;
+#ifdef GLSLES
+	precision highp float;
+#endif
+
 uniform sampler2D texture;
 uniform vec2 sourceSize;
 uniform vec2 texSizeInv;


### PR DESCRIPTION
Doing so is noncompliant with desktop GL.