### PR TITLE
Allow tuning Lanczos kernel radius

### DIFF
--- a/mkxp.json
+++ b/mkxp.json
@@ -94,6 +94,13 @@
     // "bicubicSharpness": 100,
 
 
+    // Kernel radius when using Lanczos scaling.
+    // Higher values typically look better but are slower.
+    // (default: 3)
+    //
+    // "lanczosRadius": 3,
+
+
     // Replace the game's Bitmap files with external high-res files
     // provided in the "Hires" directory.
     // (You'll also need to set the below Scaling Factors.)

--- a/mkxp.json
+++ b/mkxp.json
@@ -88,6 +88,12 @@
     // "smoothScaling": 0,
 
 
+    // Sharpness when using Bicubic scaling (0 to 100)
+    // (default: 100)
+    //
+    // "bicubicSharpness": 100,
+
+
     // Replace the game's Bitmap files with external high-res files
     // provided in the "Hires" directory.
     // (You'll also need to set the below Scaling Factors.)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -136,6 +136,7 @@ void Config::read(int argc, char *argv[]) {
         {"fixedAspectRatio", true},
         {"smoothScaling", 0},
         {"bicubicSharpness", 100},
+        {"lanczosRadius", 3},
         {"enableHires", false},
         {"textureScalingFactor", 1.},
         {"framebufferScalingFactor", 1.},
@@ -265,6 +266,7 @@ try { exp } catch (...) {}
     SET_OPT(fixedAspectRatio, boolean);
     SET_OPT(smoothScaling, integer);
     SET_OPT(bicubicSharpness, integer);
+    SET_OPT(lanczosRadius, integer);
     SET_OPT(enableHires, boolean);
     SET_OPT(textureScalingFactor, number);
     SET_OPT(framebufferScalingFactor, number);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -135,6 +135,7 @@ void Config::read(int argc, char *argv[]) {
         {"fullscreen", false},
         {"fixedAspectRatio", true},
         {"smoothScaling", 0},
+        {"bicubicSharpness", 100},
         {"enableHires", false},
         {"textureScalingFactor", 1.},
         {"framebufferScalingFactor", 1.},
@@ -263,6 +264,7 @@ try { exp } catch (...) {}
     SET_OPT(fullscreen, boolean);
     SET_OPT(fixedAspectRatio, boolean);
     SET_OPT(smoothScaling, integer);
+    SET_OPT(bicubicSharpness, integer);
     SET_OPT(enableHires, boolean);
     SET_OPT(textureScalingFactor, number);
     SET_OPT(framebufferScalingFactor, number);

--- a/src/config.h
+++ b/src/config.h
@@ -44,6 +44,7 @@ struct Config {
     bool fullscreen;
     bool fixedAspectRatio;
     int smoothScaling;
+    int bicubicSharpness;
     bool enableHires;
     double textureScalingFactor;
     double framebufferScalingFactor;

--- a/src/config.h
+++ b/src/config.h
@@ -45,6 +45,7 @@ struct Config {
     bool fixedAspectRatio;
     int smoothScaling;
     int bicubicSharpness;
+    int lanczosRadius;
     bool enableHires;
     double textureScalingFactor;
     double framebufferScalingFactor;

--- a/src/display/gl/gl-meta.cpp
+++ b/src/display/gl/gl-meta.cpp
@@ -161,6 +161,7 @@ static void _blitBegin(FBO::ID fbo, const Vec2i &size)
 			shader.applyViewportProj();
 			shader.setTranslation(Vec2i());
 			shader.setTexSize(Vec2i(size.x, size.y));
+			shader.setSharpness(shState->config().bicubicSharpness);
 		}
 
 			break;

--- a/src/display/gl/gl-meta.cpp
+++ b/src/display/gl/gl-meta.cpp
@@ -172,6 +172,7 @@ static void _blitBegin(FBO::ID fbo, const Vec2i &size)
 			shader.applyViewportProj();
 			shader.setTranslation(Vec2i());
 			shader.setTexSize(Vec2i(size.x, size.y));
+			shader.setRadius(shState->config().lanczosRadius);
 		}
 
 			break;

--- a/src/display/gl/shader.cpp
+++ b/src/display/gl/shader.cpp
@@ -777,9 +777,11 @@ BicubicShader::BicubicShader()
 	GET_U(texOffsetX);
 	GET_U(sourceSize);
 	GET_U(bc);
+}
 
-	// TODO: Maybe expose this as a setting?
-	gl.Uniform2f(u_bc, 0.0, 0.5);
+void BicubicShader::setSharpness(int sharpness)
+{
+	gl.Uniform2f(u_bc, 1.f - sharpness * 0.01f, sharpness * 0.005f);
 }
 
 Lanczos3Shader::Lanczos3Shader()

--- a/src/display/gl/shader.cpp
+++ b/src/display/gl/shader.cpp
@@ -792,10 +792,16 @@ Lanczos3Shader::Lanczos3Shader()
 
 	GET_U(texOffsetX);
 	GET_U(sourceSize);
+	GET_U(radius);
 }
 
 void Lanczos3Shader::setTexSize(const Vec2i &value)
 {
 	ShaderBase::setTexSize(value);
 	gl.Uniform2f(u_sourceSize, (float)value.x, (float)value.y);
+}
+
+void Lanczos3Shader::setRadius(int radius)
+{
+	gl.Uniform1i(u_radius, radius);
 }

--- a/src/display/gl/shader.h
+++ b/src/display/gl/shader.h
@@ -346,6 +346,9 @@ class BicubicShader : public Lanczos3Shader
 public:
 	BicubicShader();
 
+	// Sharpness ranges from 0 to 100.
+	void setSharpness(int sharpness);
+
 protected:
 	GLint u_bc;
 };

--- a/src/display/gl/shader.h
+++ b/src/display/gl/shader.h
@@ -337,8 +337,12 @@ public:
 
 	void setTexSize(const Vec2i &value);
 
+	// Kernel radius; typically 3 or 4.
+	void setRadius(int radius);
+
 protected:
 	GLint u_sourceSize;
+	GLint u_radius;
 };
 
 class BicubicShader : public Lanczos3Shader


### PR DESCRIPTION
This shouldn't yet be merged, it still references "Lanczos3" all over the place, and performance testing hasn't happened yet.

Also bicubic should probably no longer be a child of Lanczos since the radius doesn't apply to bicubic.

(Incorporates https://github.com/mkxp-z/mkxp-z/pull/135 to reduce merge conflicts, evaluate that one first.)