### PR TITLE
Refactor Bitmap constructors

### DIFF
--- a/mkxp.json
+++ b/mkxp.json
@@ -452,4 +452,10 @@
     //  "x": ...
     // }
 
+
+    // Dump tile atlas (for debugging purposes)
+    // (default: false)
+    //
+    // "dumpAtlas": false,
+
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -187,6 +187,7 @@ void Config::read(int argc, char *argv[]) {
         {"JITMaxCache", 100},
         {"JITMinCalls", 10000},
         {"YJITEnable", false},
+        {"dumpAtlas", false},
         {"bindingNames", json::object({
             {"a", "A"},
             {"b", "B"},
@@ -295,6 +296,7 @@ try { exp } catch (...) {}
     SET_OPT_CUSTOMKEY(BGM.trackCount, BGMTrackCount, integer);
     SET_STRINGOPT(customScript, customScript);
     SET_OPT(useScriptNames, boolean);
+    SET_OPT(dumpAtlas, boolean);
     
     fillStringVec(opts["preloadScript"], preloadScripts);
     fillStringVec(opts["RTP"], rtps);

--- a/src/config.h
+++ b/src/config.h
@@ -110,7 +110,7 @@ struct Config {
     std::vector<std::string> fontSubs;
     
     std::vector<std::string> rubyLoadpaths;
-    
+
     /* Editor flags */
     struct {
         bool debug;
@@ -135,6 +135,8 @@ struct Config {
     struct {
         bool enabled;
     } yjit;
+
+    bool dumpAtlas;
 
     // Keybinding action name mappings
     struct {

--- a/src/display/bitmap.h
+++ b/src/display/bitmap.h
@@ -40,12 +40,17 @@ class Bitmap : public Disposable
 public:
 	Bitmap(const char *filename);
 	Bitmap(int width, int height, bool isHires = false);
-    Bitmap(void *pixeldata, int width, int height);
+	Bitmap(void *pixeldata, int width, int height);
+	Bitmap(TEXFBO &other);
+	Bitmap(SDL_Surface *imgSurf, SDL_Surface *imgSurfHires);
+
 	/* Clone constructor */
     
     // frame is -2 for "any and all", -1 for "current", anything else for a specific frame
 	Bitmap(const Bitmap &other, int frame = -2);
 	~Bitmap();
+
+	void initFromSurface(SDL_Surface *imgSurf, Bitmap *hiresBitmap, bool freeSurface);
 
 	int width()  const;
 	int height() const;

--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -1403,17 +1403,17 @@ void Graphics::fadein(int duration) {
 }
 
 Bitmap *Graphics::snapToBitmap() {
-    Bitmap *bitmap = new Bitmap(width(), height());
-    
-    if (bitmap->hasHires()) {
-        p->compositeToBufferScaled(bitmap->getHires()->getGLTypes(), bitmap->getHires()->width(), bitmap->getHires()->height());
+    if (shState->config().enableHires) {
+        // TODO: Maybe don't reconstruct this struct every time?
+        TEXFBO tf;
+        tf.width = width();
+        tf.height = height();
+        tf.selfHires = &p->screen.getPP().frontBuffer();
+
+        return new Bitmap(tf);
     }
 
-    p->compositeToBufferScaled(bitmap->getGLTypes(), bitmap->width(), bitmap->height());
-    
-    /* Taint entire bitmap */
-    bitmap->taintArea(IntRect(0, 0, width(), height()));
-    return bitmap;
+    return new Bitmap(p->screen.getPP().frontBuffer());
 }
 
 int Graphics::width() const { return p->scResLores.x; }

--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -179,7 +179,9 @@ struct Movie
                 SDL_Delay(VIDEO_DELAY);
             }
         }
-        videoBitmap = new Bitmap(video->width, video->height);
+        // Create this Bitmap without a hires replacement, because we don't
+        // support hires replacement for Movies yet.
+        videoBitmap = new Bitmap(video->width, video->height, true);
         audioQueueHead = NULL;
         audioQueueTail = NULL;
         

--- a/src/display/tilemapvx.cpp
+++ b/src/display/tilemapvx.cpp
@@ -190,6 +190,16 @@ struct TilemapVXPrivate : public ViewportElement, TileAtlasVX::Reader
 	void rebuildAtlas()
 	{
 		TileAtlasVX::build(atlas, bitmaps);
+
+		if (shState->config().dumpAtlas)
+		{
+			Bitmap dump(atlas);
+			dump.saveToFile("dumped_atlas.png");
+			if (dump.hasHires())
+			{
+				dump.getHires()->saveToFile("dumped_atlas_hires.png");
+			}
+		}
 	}
 
 	void updateMapViewport()


### PR DESCRIPTION
These refactors make various desired functionality easier.

* Constructing Bitmap from TEXFBO: Fixes issues taking screenshots when framebuffer scaling factor != texture scaling factor; also allows dumping atlas (which is now implemented as a config option).
* Constructing Bitmap from SDL_Surface: Prerequisite for creating Bitmaps and Surfaces at different times.
* Constructing Bitmap without Hires: Fixes https://github.com/mkxp-z/mkxp-z/issues/102
