### PR TITLE
Guard against deleted bitmaps

### DIFF
--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -2523,24 +2523,6 @@ int Bitmap::maxSize(){
     return glState.caps.maxTexSize;
 }
 
-// This might look ridiculous, but apparently, it is possible
-// to encounter seemingly empty bitmaps during Graphics::update,
-// or specifically, during a Sprite's prepare function.
-
-// I have no idea why it happens, but it seems like just skipping
-// them makes it okay, so... that's what this function is for, at
-// least unless the actual source of the problem gets found, at
-// which point I'd get rid of it.
-
-// I get it to happen by trying to beat the first rival fight in
-// Pokemon Flux, on macOS. I don't think I've seen anyone bring up
-// something like this happening anywhere else, so... I dunno.
-// If a game suddenly explodes during Graphics.update, maybe try
-// breakpointing this?
-bool Bitmap::invalid() const {
-    return p == 0;
-}
-
 void Bitmap::assumeRubyGC()
 {
     p->assumingRubyGC = true;

--- a/src/display/bitmap.h
+++ b/src/display/bitmap.h
@@ -166,8 +166,6 @@ public:
 	sigslot::signal<> modified;
 
 	static int maxSize();
-    
-    bool invalid() const;
 
     void assumeRubyGC();
 


### PR DESCRIPTION
I finally know what I'm doing well enough to diagnose and solve this issue beyond "something to do with ruby's garbage collector".

Ruby is not guaranteed to delete bitmaps after any windows, sprites, etc that they are attached to. In the event that the attached object is not deleted before the next call to Graphics.update, this will most likely result in a segfault, as isDisposed() is not guaranteed to return true for a deleted bitmap.

Bitmap::invalid was added in an attempt to guard against this for sprites, but since the bitmap in question is deleted it's not guaranteed that the pointer actually points to null, which made the fix unreliable.