### PR TITLE
Take sprite rotation into account when applying the bush effect

### DIFF
--- a/shader/sprite.frag
+++ b/shader/sprite.frag
@@ -6,7 +6,10 @@ uniform lowp vec4 tone;
 uniform lowp float opacity;
 uniform lowp vec4 color;
 
-uniform float bushDepth;
+uniform bool bushY;
+uniform bool bushUnder;
+uniform float bushSlope;
+uniform float bushIntercept;
 uniform lowp float bushOpacity;
 
 uniform sampler2D pattern;
@@ -102,8 +105,9 @@ void main()
     }
 
 	/* Apply bush alpha by mathematical if */
-	lowp float underBush = float(v_texCoord.y < bushDepth);
-	frag.a *= clamp(bushOpacity + underBush, 0.0, 1.0);
+	bool underBush = (float(bushY) * v_texCoord.y + float(!bushY) * v_texCoord.x) <
+	                 (bushSlope * (float(bushY) * v_texCoord.x + float(!bushY) * v_texCoord.y) + bushIntercept);
+	frag.a *= clamp(bushOpacity + float(underBush == bushUnder), 0.0, 1.0);
 	
 	gl_FragColor = frag;
 }

--- a/src/display/gl/shader.cpp
+++ b/src/display/gl/shader.cpp
@@ -532,7 +532,10 @@ SpriteShader::SpriteShader()
 	GET_U(tone);
 	GET_U(color);
 	GET_U(opacity);
-	GET_U(bushDepth);
+	GET_U(bushY);
+	GET_U(bushUnder);
+	GET_U(bushSlope);
+	GET_U(bushIntercept);
 	GET_U(bushOpacity);
     GET_U(pattern);
     GET_U(patternBlendType);
@@ -565,9 +568,12 @@ void SpriteShader::setOpacity(float value)
 	gl.Uniform1f(u_opacity, value);
 }
 
-void SpriteShader::setBushDepth(float value)
+void SpriteShader::setBushDepth(bool bushY, bool bushUnder, float bushSlope, float bushIntercept)
 {
-	gl.Uniform1f(u_bushDepth, value);
+	gl.Uniform1f(u_bushY, bushY);
+	gl.Uniform1f(u_bushUnder, bushUnder);
+	gl.Uniform1f(u_bushSlope, bushSlope);
+	gl.Uniform1f(u_bushIntercept, bushIntercept);
 }
 
 void SpriteShader::setBushOpacity(float value)

--- a/src/display/gl/shader.h
+++ b/src/display/gl/shader.h
@@ -190,7 +190,7 @@ public:
 	void setTone(const Vec4 &value);
 	void setColor(const Vec4 &value);
 	void setOpacity(float value);
-	void setBushDepth(float value);
+	void setBushDepth(bool bushY, bool bushUnder, float bushSlope, float bushIntercept);
 	void setBushOpacity(float value);
     void setPattern(const TEX::ID pattern, const Vec2 &dimensions);
     void setPatternBlendType(int blendType);
@@ -202,7 +202,8 @@ public:
     void setInvert(bool value);
 
 private:
-	GLint u_spriteMat, u_tone, u_opacity, u_color, u_bushDepth, u_bushOpacity, u_pattern, u_renderPattern,
+	GLint u_spriteMat, u_tone, u_opacity, u_color,
+    u_bushY, u_bushUnder, u_bushSlope, u_bushIntercept, u_bushOpacity, u_pattern, u_renderPattern,
     u_patternBlendType, u_patternSizeInv, u_patternTile, u_patternOpacity, u_patternScroll, u_patternZoom, u_invert;
 };
 

--- a/src/display/gl/transform.h
+++ b/src/display/gl/transform.h
@@ -163,4 +163,22 @@ private:
 	bool dirty;
 };
 
+// Rotates a point around an origin point, counter-clockwise
+// https://stackoverflow.com/a/2259502
+static inline Vec2 rotate_point(const Vec2 &origin, const float &angle, Vec2 point)
+{
+    float s = sin(angle);
+    float c = cos(angle);
+    // translate point back to origin:
+    point.x -= origin.x;
+    point.y -= origin.y;
+    // rotate point
+    float xnew = point.x * c - point.y * s;
+    float ynew = point.x * s + point.y * c;
+    // translate point back:
+    point.x = xnew + origin.x;
+    point.y = ynew + origin.y;
+    return point;
+}
+
 #endif // TRANSFORM_H

--- a/tests/sprite-bush-rotation/spriteBushRotation.rb
+++ b/tests/sprite-bush-rotation/spriteBushRotation.rb
@@ -1,0 +1,28 @@
+b = Bitmap.new(400, 400)
+s = Sprite.new
+s.bitmap = b
+
+s.src_rect = Rect.new(100, 100, 200, 200)
+b.gradient_fill_rect(s.src_rect, Color.new(255,0,0), Color.new(0,0,255))
+
+s.x = Graphics.width / 2
+s.y = Graphics.height / 2
+s.ox = s.src_rect.width / 2
+s.oy = s.src_rect.height / 2
+
+s.bush_depth = 100
+s.bush_opacity = 128
+
+s.zoom_x = 2
+
+def rotate(s)
+	seconds_per_rotation = 12
+	s.angle += (360.0 / Graphics.frame_rate) / seconds_per_rotation
+end
+
+loop {
+	Graphics.update
+	Input.update
+	
+	rotate(s)
+}


### PR DESCRIPTION
In RGSS the bush effect covers the bottom of the sprite regardless of rotation. To replicate that, we need to calculate a slope-intercept for the shader to use.