### PR TITLE
Expand Mega Surface support

### DIFF
--- a/binding/bitmap-binding.cpp
+++ b/binding/bitmap-binding.cpp
@@ -51,10 +51,12 @@ void bitmapInitProps(Bitmap *b, VALUE self) {
     rb_iv_set(self, "font", fontObj);
 
     // Leave property as default nil if hasHires() is false.
-    if (b->hasHires()) {
-        b->assumeRubyGC();
-        wrapProperty(self, b->getHires(), "hires", BitmapType);
-    }
+    GFX_GUARD_EXC(
+        if (b->hasHires()) {
+            b->assumeRubyGC();
+            wrapProperty(self, b->getHires(), "hires", BitmapType);
+        }
+    );
 }
 
 RB_METHOD(bitmapInitialize) {
@@ -375,9 +377,7 @@ RB_METHOD(bitmapBlur) {
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    GFX_LOCK;
-    b->blur();
-    GFX_UNLOCK;
+    GFX_GUARD_EXC(b->blur(););
     
     return Qnil;
 }
@@ -388,9 +388,7 @@ RB_METHOD(bitmapRadialBlur) {
     int angle, divisions;
     rb_get_args(argc, argv, "ii", &angle, &divisions RB_ARG_END);
     
-    GFX_LOCK;
-    b->radialBlur(angle, divisions);
-    GFX_UNLOCK;
+    GFX_GUARD_EXC(b->radialBlur(angle, divisions););
     
     return Qnil;
 }
@@ -470,7 +468,11 @@ RB_METHOD(bitmapGetPlaying){
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    return rb_bool_new(b->isPlaying());
+    VALUE ret;
+    
+    GFX_GUARD_EXC(ret = rb_bool_new(b->isPlaying()););
+    
+    return ret;
 }
 
 RB_METHOD(bitmapSetPlaying){
@@ -544,7 +546,11 @@ RB_METHOD(bitmapFrames){
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    return INT2NUM(b->numFrames());
+    int ret;
+    
+    GFX_GUARD_EXC(ret = b->numFrames(););
+    
+    return INT2NUM(ret);
 }
 
 RB_METHOD(bitmapCurrentFrame){
@@ -554,7 +560,11 @@ RB_METHOD(bitmapCurrentFrame){
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    return INT2NUM(b->currentFrameI());
+    int ret;
+    
+    GFX_GUARD_EXC(ret = b->currentFrameI(););
+    
+    return INT2NUM(ret);
 }
 
 RB_METHOD(bitmapAddFrame){
@@ -611,7 +621,11 @@ RB_METHOD(bitmapNextFrame){
     
     GFX_GUARD_EXC(b->nextFrame(););
     
-    return INT2NUM(b->currentFrameI());
+    int ret;
+    
+    GFX_GUARD_EXC(ret = b->currentFrameI(););
+    
+    return INT2NUM(ret);
 }
 
 RB_METHOD(bitmapPreviousFrame){
@@ -623,7 +637,11 @@ RB_METHOD(bitmapPreviousFrame){
     
     GFX_GUARD_EXC(b->previousFrame(););
     
-    return INT2NUM(b->currentFrameI());
+    int ret;
+    
+    GFX_GUARD_EXC(ret = b->currentFrameI(););
+    
+    return INT2NUM(ret);
 }
 
 RB_METHOD(bitmapSetFPS){

--- a/shader/sprite.frag
+++ b/shader/sprite.frag
@@ -6,7 +6,10 @@ uniform lowp vec4 tone;
 uniform lowp float opacity;
 uniform lowp vec4 color;
 
-uniform float bushDepth;
+uniform bool bushY;
+uniform bool bushUnder;
+uniform float bushSlope;
+uniform float bushIntercept;
 uniform lowp float bushOpacity;
 
 uniform sampler2D pattern;
@@ -102,8 +105,9 @@ void main()
     }
 
 	/* Apply bush alpha by mathematical if */
-	lowp float underBush = float(v_texCoord.y < bushDepth);
-	frag.a *= clamp(bushOpacity + underBush, 0.0, 1.0);
+	bool underBush = (float(bushY) * v_texCoord.y + float(!bushY) * v_texCoord.x) <
+	                 (bushSlope * (float(bushY) * v_texCoord.x + float(!bushY) * v_texCoord.y) + bushIntercept);
+	frag.a *= clamp(bushOpacity + float(underBush == bushUnder), 0.0, 1.0);
 	
 	gl_FragColor = frag;
 }

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -2016,6 +2016,8 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
     
     int alignY = rect.y + (rect.h - rawTxtSurfH) / 2;
     
+    alignY = std::max(alignY, rect.y);
+    
     float squeeze = (float) rect.w / txtSurf->w;
     
     if (squeeze > 1)

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -1909,6 +1909,11 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
     GUARD_MEGA;
     GUARD_ANIMATED;
     
+    // RGSS doesn't let you draw text backwards
+    if (rect.w <= 0 || rect.h <= 0 || rect.x >= width() || rect.y >= height() ||
+        rect.w < -rect.x || rect.h < -rect.y)
+        return;
+    
     if (hasHires()) {
         Font &loresFont = getFont();
         Font &hiresFont = p->selfHires->getFont();

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -2256,7 +2256,11 @@ void Bitmap::radialBlur(int angle, int divisions)
     float baseAngle = -((float) angle / 2);
     
     ColorQuadArray qArray;
-    qArray.resize(5);
+    
+    int wNum = _width < _height ? ceil((ceil(_height / 2.0f) - (_width / 2)) / _width) : 1;
+    int hNum = _height < _width ? ceil((ceil(_width / 2.0f) - (_height / 2)) / _height) : 1;
+    
+    qArray.resize(wNum * 2 + hNum * 2 + 1);
     
     std::vector<Vertex> &vert = qArray.vertices;
     
@@ -2268,27 +2272,33 @@ void Bitmap::radialBlur(int angle, int divisions)
     
     i += Quad::setTexPosRect(&vert[i*4], texRect, posRect);
     
-    /* Upper */
-    posRect = FloatRect(0, 0, _width, -_height);
+    for (int j = 0; j < hNum; j++)
+    {
+        /* Upper */
+        posRect = FloatRect(0, (int)ceil(j / 2.0f) * 2 * -_height, _width, (j % 2 ? 1 : -1) * _height);
+        
+        i += Quad::setTexPosRect(&vert[i*4], texRect, posRect);
+        
+        /* Lower */
+        posRect = FloatRect(0, (int)ceil((j + 1) / 2.0f) * 2 * _height, _width, (j % 2 ? 1 : -1) * _height);
+        
+        i += Quad::setTexPosRect(&vert[i*4], texRect, posRect);
+    }
     
-    i += Quad::setTexPosRect(&vert[i*4], texRect, posRect);
+    for (int j = 0; j < wNum; j++)
+    {
+        /* Left */
+        posRect = FloatRect((int)ceil(j / 2.0f) * 2 * -_width, 0, (j % 2 ? 1 : -1) * _width, _height);
+        
+        i += Quad::setTexPosRect(&vert[i*4], texRect, posRect);
+        
+        /* Right */
+        posRect = FloatRect((int)ceil((j + 1) / 2.0f) * 2 * _width, 0, (j % 2 ? 1 : -1) * _width, _height);
+        
+        i += Quad::setTexPosRect(&vert[i*4], texRect, posRect);
+    }
     
-    /* Lower */
-    posRect = FloatRect(0, _height*2, _width, -_height);
-    
-    i += Quad::setTexPosRect(&vert[i*4], texRect, posRect);
-    
-    /* Left */
-    posRect = FloatRect(0, 0, -_width, _height);
-    
-    i += Quad::setTexPosRect(&vert[i*4], texRect, posRect);
-    
-    /* Right */
-    posRect = FloatRect(_width*2, 0, -_width, _height);
-    
-    i += Quad::setTexPosRect(&vert[i*4], texRect, posRect);
-    
-    for (int i = 0; i < 4*5; ++i)
+    for (int i = 0; i < 4*qArray.count(); ++i)
         vert[i].color = Vec4(1, 1, 1, opacity);
     
     qArray.commit();

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -920,7 +920,6 @@ DEF_ATTR_RD_SIMPLE(Bitmap, Hires, Bitmap*, p->selfHires)
 void Bitmap::setHires(Bitmap *hires) {
     guardDisposed();
 
-    Debug() << "BUG: High-res Bitmap setHires not fully implemented, expect bugs";
     hires->setLores(this);
     p->selfHires = hires;
 }
@@ -2446,24 +2445,11 @@ TEXFBO &Bitmap::getGLTypes() const
 
 SDL_Surface *Bitmap::surface() const
 {
-    if (hasHires()) {
-        Debug() << "BUG: High-res Bitmap surface not implemented";
-    }
-
     return p->surface;
 }
 
 SDL_Surface *Bitmap::megaSurface() const
 {
-    if (hasHires()) {
-        if (p->megaSurface) {
-            Debug() << "BUG: High-res Bitmap megaSurface not implemented (low-res has megaSurface)";
-        }
-        if (p->selfHires->megaSurface()) {
-            Debug() << "BUG: High-res Bitmap megaSurface not implemented (high-res has megaSurface)";
-        }
-    }
-
     return p->megaSurface;
 }
 

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -1819,8 +1819,6 @@ void Bitmap::replaceRaw(void *pixel_data, int size)
 {
     guardDisposed();
     
-    GUARD_MEGA;
-    
     if (hasHires()) {
         Debug() << "GAME BUG: Game is calling replaceRaw on low-res Bitmap; you may want to patch the game to improve graphics quality.";
     }
@@ -1832,8 +1830,17 @@ void Bitmap::replaceRaw(void *pixel_data, int size)
     if (size != w*h*4)
         throw Exception(Exception::MKXPError, "Replacement bitmap data is not large enough (given %i bytes, need %i)", size, requiredsize);
     
-    TEX::bind(getGLTypes().tex);
-    TEX::uploadImage(w, h, pixel_data, GL_RGBA);
+    if (p->megaSurface)
+    {
+        // This should always be true
+        if (p->megaSurface->format->BitsPerPixel == 32)
+            memcpy(p->megaSurface->pixels, pixel_data, w*h*4);
+    }
+    else
+    {
+        TEX::bind(getGLTypes().tex);
+        TEX::uploadImage(w, h, pixel_data, GL_RGBA);
+    }
     
     taintArea(IntRect(0,0,w,h));
     p->onModified();

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -1945,8 +1945,6 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
     SDL_Color c = fontColor.toSDLColor();
     c.a = 255;
     
-    float txtAlpha = fontColor.norm.w;
-    
     SDL_Surface *txtSurf;
     
     if (p->font->isSolid())
@@ -2018,131 +2016,22 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
     if (squeeze > 1)
         squeeze = 1;
     
-    FloatRect posRect(alignX, alignY, txtSurf->w * squeeze, txtSurf->h);
+    IntRect destRect(alignX, alignY, 0, 0);
+    destRect.w = std::min(rect.w, (int)(txtSurf->w * squeeze));
+    destRect.h = std::min(rect.h, txtSurf->h);
     
-    Vec2i gpTexSize;
-    shState->ensureTexSize(txtSurf->w, txtSurf->h, gpTexSize);
+    destRect.w = std::min(destRect.w, width() - destRect.x);
+    destRect.h = std::min(destRect.h, height() - destRect.y);
     
-    bool fastBlit = !p->touchesTaintedArea(posRect) && txtAlpha == 1.0f;
+    IntRect sourceRect;
+    sourceRect.w = destRect.w / squeeze;
+    sourceRect.h = destRect.h;
     
-    if (fastBlit)
-    {
-        if (squeeze == 1.0f && !shState->config().subImageFix)
-        {
-            /* Even faster: upload directly to bitmap texture.
-             * We have to make sure the posRect lies within the texture
-             * boundaries or texSubImage will generate errors.
-             * If it partly lies outside bounds we have to upload
-             * the clipped visible part of it. */
-            SDL_Rect btmRect;
-            btmRect.x = btmRect.y = 0;
-            btmRect.w = width();
-            btmRect.h = height();
-            
-            SDL_Rect txtRect;
-            txtRect.x = posRect.x;
-            txtRect.y = posRect.y;
-            txtRect.w = posRect.w;
-            txtRect.h = posRect.h;
-            
-            SDL_Rect inters;
-            
-            /* If we have no intersection at all,
-             * there's nothing to upload to begin with */
-            if (SDL_IntersectRect(&btmRect, &txtRect, &inters))
-            {
-                bool subImage = false;
-                int subSrcX = 0, subSrcY = 0;
-                
-                if (inters.w != txtRect.w || inters.h != txtRect.h)
-                {
-                    /* Clip the text surface */
-                    subSrcX = inters.x - txtRect.x;
-                    subSrcY = inters.y - txtRect.y;
-                    subImage = true;
-                    
-                    posRect.x = inters.x;
-                    posRect.y = inters.y;
-                    posRect.w = inters.w;
-                    posRect.h = inters.h;
-                }
-                
-                TEX::bind(p->gl.tex);
-                
-                if (!subImage)
-                {
-                    TEX::uploadSubImage(posRect.x, posRect.y,
-                                        posRect.w, posRect.h,
-                                        txtSurf->pixels, GL_RGBA);
-                }
-                else
-                {
-                    GLMeta::subRectImageUpload(txtSurf->w, subSrcX, subSrcY,
-                                               posRect.x, posRect.y,
-                                               posRect.w, posRect.h,
-                                               txtSurf, GL_RGBA);
-                    GLMeta::subRectImageEnd();
-                }
-            }
-        }
-        else
-        {
-            /* Squeezing involved: need to use intermediary TexFBO */
-            TEXFBO &gpTF = shState->gpTexFBO(txtSurf->w, txtSurf->h);
-            
-            TEX::bind(gpTF.tex);
-            TEX::uploadSubImage(0, 0, txtSurf->w, txtSurf->h, txtSurf->pixels, GL_RGBA);
-            
-            GLMeta::blitBegin(p->gl);
-            GLMeta::blitSource(gpTF);
-            GLMeta::blitRectangle(IntRect(0, 0, txtSurf->w, txtSurf->h),
-                                  posRect, true);
-            GLMeta::blitEnd();
-        }
-    }
-    else
-    {
-        /* Aquire a partial copy of the destination
-         * buffer we're about to render to */
-        TEXFBO &gpTex2 = shState->gpTexFBO(posRect.w, posRect.h);
-        
-        GLMeta::blitBegin(gpTex2);
-        GLMeta::blitSource(p->gl);
-        GLMeta::blitRectangle(posRect, Vec2i());
-        GLMeta::blitEnd();
-        
-        FloatRect bltRect(0, 0,
-                          (float) (gpTexSize.x * squeeze) / gpTex2.width,
-                          (float) gpTexSize.y / gpTex2.height);
-        
-        BltShader &shader = shState->shaders().blt;
-        shader.bind();
-        shader.setTexSize(gpTexSize);
-        shader.setSource();
-        shader.setDestination(gpTex2.tex);
-        shader.setSubRect(bltRect);
-        shader.setOpacity(txtAlpha);
-        
-        shState->bindTex();
-        TEX::uploadSubImage(0, 0, txtSurf->w, txtSurf->h, txtSurf->pixels, GL_RGBA);
-        TEX::setSmooth(true);
-        
-        Quad &quad = shState->gpQuad();
-        quad.setTexRect(FloatRect(0, 0, txtSurf->w, txtSurf->h));
-        quad.setPosRect(posRect);
-        
-        p->bindFBO();
-        p->pushSetViewport(shader);
-        
-        p->blitQuad(quad);
-        
-        p->popViewport();
-    }
-    
-    SDL_FreeSurface(txtSurf);
-    p->addTaintedArea(posRect);
-    
-    p->onModified();
+    Bitmap *txtBitmap = new Bitmap(txtSurf, nullptr, true);
+    TEX::setSmooth(true);
+    stretchBlt(destRect, *txtBitmap, sourceRect, fontColor.alpha);
+    TEX::setSmooth(false);
+    delete txtBitmap;
 }
 
 /* http://www.lemoda.net/c/utf8-to-ucs2/index.html */

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -1950,6 +1950,15 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
     SDL_Color c = fontColor.toSDLColor();
     c.a = 255;
     
+    // Trim the text to only fill double the rect width
+    int charLimit = 0;
+    float squeezeLimit = 0.5f;
+    if (TTF_MeasureUTF8(font, str, std::min(width() - rect.x, rect.w) / squeezeLimit, &charLimit, nullptr) == 0)
+    {
+        fixed = fixed.substr(0, charLimit + 1);
+        str = fixed.c_str();
+    }
+    
     SDL_Surface *txtSurf;
     
     if (p->font->isSolid())
@@ -2023,7 +2032,7 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
      * have made the rects bigger to compensate, so we should probably match it */
     float squeeze = (float) rect.w / txtSurf->w;
     
-    squeeze = clamp(squeeze, 0.5f, 1.0f);
+    squeeze = clamp(squeeze, squeezeLimit, 1.0f);
     
     IntRect destRect(alignX, alignY, 0, 0);
     destRect.w = std::min(rect.w, (int)(txtSurf->w * squeeze));

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -1058,128 +1058,161 @@ void Bitmap::stretchBlt(IntRect destRect,
         return;
     
     SDL_Surface *srcSurf = source.megaSurface();
+    SDL_Surface *blitTemp = 0;
+    bool touchesTaintedArea = p->touchesTaintedArea(destRect);
     
-    if (srcSurf && shState->config().subImageFix)
-    {
-        /* Blit from software surface, for broken GL drivers */
-        Vec2i gpTexSize;
-        shState->ensureTexSize(sourceRect.w, sourceRect.h, gpTexSize);
-        shState->bindTex();
-        
-        GLMeta::subRectImageUpload(srcSurf->w, sourceRect.x, sourceRect.y, 0, 0,
-                                   sourceRect.w, sourceRect.h, srcSurf, GL_RGBA);
-        GLMeta::subRectImageEnd();
-        
-        SimpleShader &shader = shState->shaders().simple;
-        shader.bind();
-        shader.setTranslation(Vec2i());
-        shader.setTexSize(gpTexSize);
-        
-        p->pushSetViewport(shader);
-        p->bindFBO();
-        
-        Quad &quad = shState->gpQuad();
-        quad.setTexRect(FloatRect(0, 0, sourceRect.w, sourceRect.h));
-        quad.setPosRect(destRect);
-        
-        p->blitQuad(quad);
-        p->popViewport();
-        
-        p->addTaintedArea(destRect);
-        p->onModified();
-        
-        return;
-    }
-    else if (srcSurf)
-    {
-        /* Blit from software surface */
-        /* Don't do transparent blits for now */
-        if (opacity < 255)
-            source.ensureNonMega();
-        
-        SDL_Rect srcRect = sourceRect;
-        SDL_Rect dstRect = destRect;
-        SDL_Rect btmRect = { 0, 0, width(), height() };
-        SDL_Rect bltRect;
-        
-        if (SDL_IntersectRect(&btmRect, &dstRect, &bltRect) != SDL_TRUE)
-            return;
-        
-        int bpp;
-        Uint32 rMask, gMask, bMask, aMask;
-        SDL_PixelFormatEnumToMasks(SDL_PIXELFORMAT_ABGR8888,
-                                   &bpp, &rMask, &gMask, &bMask, &aMask);
-        SDL_Surface *blitTemp =
-        SDL_CreateRGBSurface(0, destRect.w, destRect.h, bpp, rMask, gMask, bMask, aMask);
-        
-        SDL_BlitScaled(srcSurf, &srcRect, blitTemp, 0);
-        
-        TEX::bind(getGLTypes().tex);
-        
-        if (bltRect.w == dstRect.w && bltRect.h == dstRect.h)
-        {
-            /* Dest rectangle lies within bounding box */
-            TEX::uploadSubImage(destRect.x, destRect.y,
-                                destRect.w, destRect.h,
-                                blitTemp->pixels, GL_RGBA);
-        }
-        else
-        {
-            /* Clipped blit */
-            GLMeta::subRectImageUpload(blitTemp->w, bltRect.x - dstRect.x, bltRect.y - dstRect.y,
-                                       bltRect.x, bltRect.y, bltRect.w, bltRect.h, blitTemp, GL_RGBA);
-            GLMeta::subRectImageEnd();
-        }
-        
-        SDL_FreeSurface(blitTemp);
-        
-        p->onModified();
-        return;
-    }
-    
-    if (opacity == 255 && !p->touchesTaintedArea(destRect))
+    if (!srcSurf && opacity == 255 && !touchesTaintedArea)
     {
         /* Fast blit */
         GLMeta::blitBegin(getGLTypes());
         GLMeta::blitSource(source.getGLTypes());
-        GLMeta::blitRectangle(sourceRect, destRect);
+        GLMeta::blitRectangle(sourceRect, destRect, false);
         GLMeta::blitEnd();
     }
     else
     {
-        /* Fragment pipeline */
-        float normOpacity = (float) opacity / 255.0f;
-        
-        TEXFBO &gpTex = shState->gpTexFBO(destRect.w, destRect.h);
-        
-        GLMeta::blitBegin(gpTex);
-        GLMeta::blitSource(getGLTypes());
-        GLMeta::blitRectangle(destRect, Vec2i());
-        GLMeta::blitEnd();
-        
-        FloatRect bltSubRect((float) sourceRect.x / source.width(),
-                             (float) sourceRect.y / source.height(),
-                             ((float) source.width() / sourceRect.w) * ((float) destRect.w / gpTex.width),
-                             ((float) source.height() / sourceRect.h) * ((float) destRect.h / gpTex.height));
-        
-        BltShader &shader = shState->shaders().blt;
-        shader.bind();
-        shader.setDestination(gpTex.tex);
-        shader.setSubRect(bltSubRect);
-        shader.setOpacity(normOpacity);
-        
-        Quad &quad = shState->gpQuad();
-        quad.setTexPosRect(sourceRect, destRect);
-        quad.setColor(Vec4(1, 1, 1, normOpacity));
-        
-        source.p->bindTexture(shader, false);
-        p->bindFBO();
-        p->pushSetViewport(shader);
-        
-        p->blitQuad(quad);
-        
-        p->popViewport();
+        if (srcSurf)
+        {
+            SDL_Rect srcRect = sourceRect;
+            bool subImageFix = shState->config().subImageFix;
+            bool srcRectTooBig = srcRect.w > glState.caps.maxTexSize ||
+                                 srcRect.h > glState.caps.maxTexSize;
+            bool srcSurfTooBig = srcSurf->w > glState.caps.maxTexSize || 
+                                 srcSurf->h > glState.caps.maxTexSize;
+            
+            if (srcRectTooBig || srcSurfTooBig)
+            {
+                Uint8 tempAlpha;
+                SDL_GetSurfaceAlphaMod(srcSurf, &tempAlpha);
+                SDL_SetSurfaceAlphaMod(srcSurf, opacity);
+                
+                if (srcRectTooBig)
+                {
+                    /* We have to resize it here anyway, so use software resizing */
+                    blitTemp =
+                        SDL_CreateRGBSurface(0, abs(destRect.w), abs(destRect.h), p->format->BitsPerPixel,
+                                             p->format->Rmask, p->format->Gmask,
+                                             p->format->Bmask, p->format->Amask);
+                    SDL_BlitScaled(srcSurf, &srcRect, blitTemp, 0);
+                }
+                else
+                {
+                    /* Just crop it, let the shader resize it later */
+                    blitTemp =
+                        SDL_CreateRGBSurface(0, sourceRect.w, sourceRect.h, p->format->BitsPerPixel,
+                                             p->format->Rmask, p->format->Gmask,
+                                             p->format->Bmask, p->format->Amask);
+                    SDL_BlitSurface(srcSurf, &srcRect, blitTemp, 0);
+                }
+                
+                SDL_SetSurfaceAlphaMod(srcSurf, tempAlpha);
+                
+                opacity = 255;
+                srcSurf = blitTemp;
+                
+                sourceRect.w = srcSurf->w;
+                sourceRect.h = srcSurf->h;
+                sourceRect.x = 0;
+                sourceRect.y = 0;
+            }
+            
+            if (opacity == 255 && !touchesTaintedArea)
+            {
+                if (!subImageFix &&
+                    srcSurf->w == destRect.w && srcSurf->h == destRect.h &&
+                    srcSurf->w == sourceRect.w && srcSurf->h == sourceRect.h)
+                {
+                    /* No scaling needed */
+                    TEX::bind(getGLTypes().tex);
+                    TEX::uploadSubImage(destRect.x, destRect.y,
+                                        destRect.w, destRect.h,
+                                        srcSurf->pixels, GL_RGBA);
+                }
+                else
+                {
+                    /* Resizing or subImageFix involved: need to use intermediary TexFBO */
+                    TEXFBO &gpTF = shState->gpTexFBO(srcSurf->w, srcSurf->h);
+                    
+                    TEX::bind(gpTF.tex);
+                    TEX::uploadSubImage(0, 0, srcSurf->w, srcSurf->h, srcSurf->pixels, GL_RGBA);
+                    
+                    GLMeta::blitBegin(p->gl);
+                    GLMeta::blitSource(gpTF);
+                    /* True sets the scaler to use GL_LINEAR, 
+                     * false leaves it alone (GL_NEAREST by default) */
+                    GLMeta::blitRectangle(sourceRect, destRect, false);
+                    GLMeta::blitEnd();
+                }
+            }
+        }
+        if (opacity < 255 || touchesTaintedArea)
+        {
+            /* We're touching a tainted area or still need to reduce opacity */
+             
+            /* Fragment pipeline */
+            float normOpacity = (float) opacity / 255.0f;
+            
+            TEXFBO &gpTex = shState->gpTexFBO(destRect.w, destRect.h);
+            Vec2i gpTexSize;
+            
+            GLMeta::blitBegin(gpTex);
+            GLMeta::blitSource(getGLTypes());
+            GLMeta::blitRectangle(destRect, Vec2i());
+            GLMeta::blitEnd();
+            
+            int sourceWidth, sourceHeight;
+            FloatRect bltSubRect;
+            if (srcSurf)
+            {
+                shState->ensureTexSize(srcSurf->w, srcSurf->h, gpTexSize);
+                sourceWidth = gpTexSize.x;
+                sourceHeight = gpTexSize.y;
+            }
+            else
+            {
+                sourceWidth = source.width();
+                sourceHeight = source.height();
+            }
+                bltSubRect = FloatRect((float) sourceRect.x / sourceWidth,
+                                       (float) sourceRect.y / sourceHeight,
+                                       ((float) sourceWidth / sourceRect.w) * ((float) destRect.w / gpTex.width),
+                                       ((float) sourceHeight / sourceRect.h) * ((float) destRect.h / gpTex.height));
+            
+            
+            BltShader &shader = shState->shaders().blt;
+            shader.bind();
+            if (srcSurf)
+            {
+                shader.setTexSize(gpTexSize);
+                shader.setSource();
+            }
+            shader.setDestination(gpTex.tex);
+            shader.setSubRect(bltSubRect);
+            shader.setOpacity(normOpacity);
+            
+            if (srcSurf)
+            {
+                shState->bindTex();
+                TEX::uploadSubImage(0, 0, srcSurf->w, srcSurf->h, srcSurf->pixels, GL_RGBA);
+            }
+            
+            Quad &quad = shState->gpQuad();
+            quad.setTexPosRect(sourceRect, destRect);
+            quad.setColor(Vec4(1, 1, 1, normOpacity));
+            
+            if (!srcSurf)
+                source.p->bindTexture(shader, false);
+            p->bindFBO();
+            p->pushSetViewport(shader);
+            
+            p->blitQuad(quad);
+            
+            p->popViewport();
+        }
     }
+    
+    if (blitTemp)
+        SDL_FreeSurface(blitTemp);
     
     p->addTaintedArea(destRect);
     p->onModified();

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -731,7 +731,6 @@ Bitmap::Bitmap(void *pixeldata, int width, int height)
 Bitmap::Bitmap(const Bitmap &other, int frame)
 {
     other.guardDisposed();
-    other.ensureNonMega();
     if (frame > -2) other.ensureAnimated();
     
     if (other.hasHires()) {
@@ -739,9 +738,13 @@ Bitmap::Bitmap(const Bitmap &other, int frame)
     }
 
     p = new BitmapPrivate(this);
-    
+
+    if (other.isMega())
+    {
+        p->megaSurface = SDL_ConvertSurfaceFormat(other.p->megaSurface, p->format->format, 0);
+    }
     // TODO: Clean me up
-    if (!other.isAnimated() || frame >= -1) {
+    else if (!other.isAnimated() || frame >= -1) {
         p->gl = shState->texPool().request(other.width(), other.height());
         
         GLMeta::blitBegin(p->gl);

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -633,7 +633,7 @@ Bitmap::Bitmap(const char *filename)
 
     SDL_Surface *imgSurf = handler.surface;
 
-    initFromSurface(imgSurf, hiresBitmap, false);
+    initFromSurface(imgSurf, hiresBitmap, hiresBitmap && hiresBitmap->isMega());
 }
 
 Bitmap::Bitmap(int width, int height, bool isHires)
@@ -652,7 +652,7 @@ Bitmap::Bitmap(int width, int height, bool isHires)
         hiresBitmap->setLores(this);
     }
 
-    if (width > glState.caps.maxTexSize || height > glState.caps.maxTexSize)
+    if (width > glState.caps.maxTexSize || height > glState.caps.maxTexSize || (hiresBitmap && hiresBitmap->isMega()))
     {
         p = new BitmapPrivate(this);
         SDL_Surface *surface = SDL_CreateRGBSurface(0, width, height, p->format->BitsPerPixel,

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -2018,10 +2018,12 @@ void Bitmap::drawText(const IntRect &rect, const char *str, int align)
     
     alignY = std::max(alignY, rect.y);
     
+    /* FIXME: RGSS begins squeezing the text before it fills the rect.
+     * While this is extremely undesirable, a number of games will understandably
+     * have made the rects bigger to compensate, so we should probably match it */
     float squeeze = (float) rect.w / txtSurf->w;
     
-    if (squeeze > 1)
-        squeeze = 1;
+    squeeze = clamp(squeeze, 0.5f, 1.0f);
     
     IntRect destRect(alignX, alignY, 0, 0);
     destRect.w = std::min(rect.w, (int)(txtSurf->w * squeeze));

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -927,23 +927,11 @@ IntRect Bitmap::rect() const
 }
 
 void Bitmap::blt(int x, int y,
-                 const Bitmap &source, IntRect rect,
+                 const Bitmap &source, const IntRect &rect,
                  int opacity)
 {
     if (source.isDisposed())
         return;
-    
-    // FIXME: RGSS allows the source rect to both lie outside
-    // the bitmap rect and be inverted in both directions;
-    // clamping only covers a subset of these cases (and
-    // doesn't fix anything for a direct stretch_blt call).
-    
-    /* Clamp rect to source bitmap size */
-    if (rect.x + rect.w > source.width())
-        rect.w = source.width() - rect.x;
-    
-    if (rect.y + rect.h > source.height())
-        rect.h = source.height() - rect.y;
     
     stretchBlt(IntRect(x, y, rect.w, rect.h),
                source, rect, opacity);

--- a/src/display/bitmap.cpp
+++ b/src/display/bitmap.cpp
@@ -2523,24 +2523,6 @@ int Bitmap::maxSize(){
     return glState.caps.maxTexSize;
 }
 
-// This might look ridiculous, but apparently, it is possible
-// to encounter seemingly empty bitmaps during Graphics::update,
-// or specifically, during a Sprite's prepare function.
-
-// I have no idea why it happens, but it seems like just skipping
-// them makes it okay, so... that's what this function is for, at
-// least unless the actual source of the problem gets found, at
-// which point I'd get rid of it.
-
-// I get it to happen by trying to beat the first rival fight in
-// Pokemon Flux, on macOS. I don't think I've seen anyone bring up
-// something like this happening anywhere else, so... I dunno.
-// If a game suddenly explodes during Graphics.update, maybe try
-// breakpointing this?
-bool Bitmap::invalid() const {
-    return p == 0;
-}
-
 void Bitmap::assumeRubyGC()
 {
     p->assumingRubyGC = true;

--- a/src/display/bitmap.h
+++ b/src/display/bitmap.h
@@ -34,6 +34,68 @@ struct TEXFBO;
 struct SDL_Surface;
 
 struct BitmapPrivate;
+struct ChildPrivate;
+struct ChildPublic
+{
+    // The real offset and zoom. Initialized to -1.0f, to determine if it's a Window.
+    Vec2i realOffset;
+    Vec2 realZoom;
+    
+    // The effective offset and zoom, after adjusting for the child's size, position, and shrinkage.
+    Vec2 offset;
+    Vec2 zoom;
+    
+    // The window's dimensions. Used by Windows.
+    int width;
+    int height;
+    
+    // Needed for Sprites, initialized to the parent's dimensions and used by everything.
+    IntRect realSrcRect;
+    IntRect srcRect;
+    
+    // sceneRect is the viewport, used for determining what's actually visible.
+    // sceneOrig is the viewport's offset, and functions similarly to x/y.
+    const IntRect *sceneRect;
+    const Vec2i *sceneOrig;
+    
+    // The Sprite or Window's position, for modifying the offset and as the origin for rotations.
+    // Also used for Planes instead of realOffset, due to how zooming interacts with it.
+    // (Planes still output to offset, though)
+    int x;
+    int y;
+    // Should the child wrap around. Only used by Planes.
+    bool wrap;
+    
+    // Will the child be mirrored. Used by Sprites.
+    bool mirrored;
+    
+    // Used by Sprites.
+    float angle;
+    int waveAmp;
+    
+    // If the child won't even be visible, then we can skip all drawing operations for it.
+    bool isVisible;
+    
+    ChildPublic()
+    :
+    width(0),
+    height(0),
+    x(0),
+    y(0),
+    sceneRect(0),
+    sceneOrig(0),
+    wrap(false),
+    mirrored(false),
+    angle(0),
+    waveAmp(0),
+    isVisible(true)
+    {
+    	realZoom.x = realZoom.y = -1.0f;
+    	zoom.x = zoom.y = -1.0f;
+    }
+};
+
+
 // FIXME make this class use proper RGSS classes again
 class Bitmap : public Disposable
 {
@@ -51,6 +113,10 @@ public:
 	~Bitmap();
 
 	void initFromSurface(SDL_Surface *imgSurf, Bitmap *hiresBitmap, bool forceMega = false);
+
+	Bitmap *spawnChild();
+	ChildPublic *getChildInfo();
+	void childUpdate();
 
 	int width()  const;
 	int height() const;

--- a/src/display/bitmap.h
+++ b/src/display/bitmap.h
@@ -42,7 +42,7 @@ public:
 	Bitmap(int width, int height, bool isHires = false);
 	Bitmap(void *pixeldata, int width, int height);
 	Bitmap(TEXFBO &other);
-	Bitmap(SDL_Surface *imgSurf, SDL_Surface *imgSurfHires);
+	Bitmap(SDL_Surface *imgSurf, SDL_Surface *imgSurfHires, bool forceMega = false);
 
 	/* Clone constructor */
     
@@ -50,7 +50,7 @@ public:
 	Bitmap(const Bitmap &other, int frame = -2);
 	~Bitmap();
 
-	void initFromSurface(SDL_Surface *imgSurf, Bitmap *hiresBitmap, bool freeSurface);
+	void initFromSurface(SDL_Surface *imgSurf, Bitmap *hiresBitmap, bool forceMega = false);
 
 	int width()  const;
 	int height() const;

--- a/src/display/bitmap.h
+++ b/src/display/bitmap.h
@@ -166,8 +166,6 @@ public:
 	sigslot::signal<> modified;
 
 	static int maxSize();
-    
-    bool invalid() const;
 
     void assumeRubyGC();
 

--- a/src/display/bitmap.h
+++ b/src/display/bitmap.h
@@ -92,6 +92,9 @@ public:
 
 	void clear();
 
+	/* Creates a surface and assigns it to p->surface */
+	void createSurface() const;
+
 	Color getPixel(int x, int y) const;
 	void setPixel(int x, int y, const Color &color);
     

--- a/src/display/bitmap.h
+++ b/src/display/bitmap.h
@@ -63,7 +63,7 @@ public:
 	IntRect rect() const;
 
 	void blt(int x, int y,
-	         const Bitmap &source, IntRect rect,
+	         const Bitmap &source, const IntRect &rect,
 	         int opacity = 255);
 
 	void stretchBlt(IntRect destRect,

--- a/src/display/bitmap.h
+++ b/src/display/bitmap.h
@@ -66,8 +66,8 @@ public:
 	         const Bitmap &source, IntRect rect,
 	         int opacity = 255);
 
-	void stretchBlt(const IntRect &destRect,
-	                const Bitmap &source, const IntRect &sourceRect,
+	void stretchBlt(IntRect destRect,
+	                const Bitmap &source, IntRect sourceRect,
 	                int opacity = 255);
 
 	void fillRect(int x, int y,

--- a/src/display/font.cpp
+++ b/src/display/font.cpp
@@ -158,9 +158,9 @@ void SharedFontState::initFontSetCB(SDL_RWops &ops,
 
 	FontSet &set = p->sets[family];
 
-	if (style == "Regular")
+	if (style == "Regular" && set.regular.empty())
 		set.regular = filename;
-	else
+	else if (style != "Regular" && set.other.empty())
 		set.other = filename;
 }
 

--- a/src/display/font.cpp
+++ b/src/display/font.cpp
@@ -212,14 +212,28 @@ _TTF_Font *SharedFontState::getFont(std::string family,
 		shState->fileSystem().openReadRaw(*ops, path, true);
 	}
 
-	// FIXME 0.9 is guesswork at this point
-//	float gamma = (96.0/45.0)*(5.0/14.0)*(size-5);
-//	font = TTF_OpenFontRW(ops, 1, gamma /** .90*/);
-	font = TTF_OpenFontRW(ops, 1, size* 0.90f);
+	// Setting the initial dpi too low fails
+	int dpi = 50;
+	font = TTF_OpenFontDPIRW(ops, 1, size, dpi, dpi);
 
 	if (!font)
 		throw Exception(Exception::SDLError, "%s", SDL_GetError());
 
+	// Figure out the dpi needed. It varies by font.
+	// There can be more than one for a given height, which potentially have different widths,
+	// but the range shrinks toward the biggest one as the size gets bigger
+	// Using the biggest one
+	while(TTF_FontHeight(font) <= size)
+	{
+		++dpi;
+		TTF_SetFontSizeDPI(font, size, dpi, dpi);
+	}
+	while(TTF_FontHeight(font) > size)
+	{
+		--dpi;
+		TTF_SetFontSizeDPI(font, size, dpi, dpi);
+	}
+	
 	p->pool.insert(key, font);
 
 	return font;

--- a/src/display/gl/shader.cpp
+++ b/src/display/gl/shader.cpp
@@ -480,7 +480,10 @@ SpriteShader::SpriteShader()
 	GET_U(tone);
 	GET_U(color);
 	GET_U(opacity);
-	GET_U(bushDepth);
+	GET_U(bushY);
+	GET_U(bushUnder);
+	GET_U(bushSlope);
+	GET_U(bushIntercept);
 	GET_U(bushOpacity);
     GET_U(pattern);
     GET_U(patternBlendType);
@@ -513,9 +516,12 @@ void SpriteShader::setOpacity(float value)
 	gl.Uniform1f(u_opacity, value);
 }
 
-void SpriteShader::setBushDepth(float value)
+void SpriteShader::setBushDepth(bool bushY, bool bushUnder, float bushSlope, float bushIntercept)
 {
-	gl.Uniform1f(u_bushDepth, value);
+	gl.Uniform1f(u_bushY, bushY);
+	gl.Uniform1f(u_bushUnder, bushUnder);
+	gl.Uniform1f(u_bushSlope, bushSlope);
+	gl.Uniform1f(u_bushIntercept, bushIntercept);
 }
 
 void SpriteShader::setBushOpacity(float value)

--- a/src/display/gl/shader.h
+++ b/src/display/gl/shader.h
@@ -190,7 +190,7 @@ public:
 	void setTone(const Vec4 &value);
 	void setColor(const Vec4 &value);
 	void setOpacity(float value);
-	void setBushDepth(float value);
+	void setBushDepth(bool bushY, bool bushUnder, float bushSlope, float bushIntercept);
 	void setBushOpacity(float value);
     void setPattern(const TEX::ID pattern, const Vec2 &dimensions);
     void setPatternBlendType(int blendType);
@@ -202,7 +202,8 @@ public:
     void setInvert(bool value);
 
 private:
-	GLint u_spriteMat, u_tone, u_opacity, u_color, u_bushDepth, u_bushOpacity, u_pattern, u_renderPattern,
+	GLint u_spriteMat, u_tone, u_opacity, u_color,
+    u_bushY, u_bushUnder, u_bushSlope, u_bushIntercept, u_bushOpacity, u_pattern, u_renderPattern,
     u_patternBlendType, u_patternSizeInv, u_patternTile, u_patternOpacity, u_patternScroll, u_patternZoom, u_invert;
 };
 

--- a/src/display/gl/transform.h
+++ b/src/display/gl/transform.h
@@ -68,6 +68,7 @@ public:
 
 	Vec2 &getPosition() { return position; }
 	Vec2 &getOrigin()   { return origin;   }
+	Vec2 &getSrcRectOrigin()   { return srcRectOrigin;   }
 	Vec2 &getScale()    { return scale;    }
 	float getRotation() { return rotation; }
 
@@ -76,9 +77,9 @@ public:
 		return Vec2i(position.x, position.y);
 	}
 
-	Vec2i getOriginI() const
+	Vec2i getAdjustedOriginI() const
 	{
-		return Vec2i(origin.x, origin.y);
+		return Vec2i(adjustedOrigin.x, adjustedOrigin.y);
 	}
 
 	void setPosition(const Vec2 &value)
@@ -90,6 +91,16 @@ public:
 	void setOrigin(const Vec2 &value)
 	{
 		origin = value;
+		adjustedOrigin.x = origin.x + srcRectOrigin.x;
+		adjustedOrigin.y = origin.y + srcRectOrigin.y;
+		dirty = true;
+	}
+
+	void setSrcRectOrigin(const Vec2 &value)
+	{
+		srcRectOrigin = value;
+		adjustedOrigin.x = origin.x + srcRectOrigin.x;
+		adjustedOrigin.y = origin.y + srcRectOrigin.y;
 		dirty = true;
 	}
 
@@ -139,8 +150,8 @@ private:
 		float syc    = scale.y * cosine;
 		float sxs    = scale.x * sine;
 		float sys    = scale.y * sine;
-		float tx     = -origin.x * sxc - origin.y * sys + position.x + offset.x;
-		float ty     =  origin.x * sxs - origin.y * syc + position.y + offset.y;
+		float tx     = -adjustedOrigin.x * sxc - adjustedOrigin.y * sys + position.x + offset.x;
+		float ty     =  adjustedOrigin.x * sxs - adjustedOrigin.y * syc + position.y + offset.y;
 
 		matrix[0]  =  sxc;
 		matrix[1]  = -sxs;
@@ -152,6 +163,8 @@ private:
 
 	Vec2 position;
 	Vec2 origin;
+	Vec2 srcRectOrigin;
+	Vec2 adjustedOrigin;
 	Vec2 scale;
 	float rotation;
 

--- a/src/display/sprite.cpp
+++ b/src/display/sprite.cpp
@@ -44,6 +44,12 @@
 
 #include "sigslot/signal.hpp"
 
+static float fwrap(float value, float range)
+{
+    float res = fmod(value, range);
+    return res < 0 ? res + range : res;
+}
+
 struct SpritePrivate
 {
     Bitmap *bitmap;
@@ -57,6 +63,11 @@ struct SpritePrivate
     bool mirrored;
     int bushDepth;
     float efBushDepth;
+    float bushSlope;
+    float bushIntercept;
+    bool bushY;
+    bool bushUnder;
+    bool bushDirty;
     NormValue bushOpacity;
     NormValue opacity;
     BlendType blendType;
@@ -103,7 +114,11 @@ struct SpritePrivate
     srcRect(&tmp.rect),
     mirrored(false),
     bushDepth(0),
-    efBushDepth(0),
+    bushSlope(0),
+    bushIntercept(0),
+    bushY(true),
+    bushUnder(true),
+    bushDirty(true),
     bushOpacity(128),
     opacity(255),
     blendType(BlendNormal),
@@ -144,12 +159,74 @@ struct SpritePrivate
         if (nullOrDisposed(bitmap))
             return;
         
-        /* Calculate effective (normalized) bush depth */
-        float texBushDepth = (bushDepth / trans.getScale().y) -
-        (srcRect->y + srcRect->height) +
-        bitmap->height();
+        bushDirty = false;
         
-        efBushDepth = 1.0f - texBushDepth / bitmap->height();
+        if (bushDepth <= 0)
+        {
+            bushSlope = 0;
+            bushIntercept = 0;
+            bushY = true;
+            bushUnder = true;
+            return;
+        }
+        
+        // Invert the angle if mirrored
+        int mirror = mirrored ? -1 : 1;
+        float angle = fwrap(mirror * trans.getRotation(), 360);
+        // Calculate the slope in segments of 45deg, so I don't have to deal with near-infinite slopes
+        bushSlope = tan(abs(fwrap(angle - 45, 90) - 45) * M_PI / 180.0f);
+        // Manually set negative slopes
+        bushSlope *= fwrap(angle, 180) > 90 ? -1 : 1;
+        
+        
+        // If the angle is within 45deg of 90deg or 270deg we use the x-axis instead
+        // Additionally, since the shader's coordinates are percentage based, we need to make
+        // the slope relative to the scaled bitmap's ratio
+        float scaledW = bitmap->width() * trans.getScale().x;
+        float scaledH = bitmap->height() * trans.getScale().y;
+        if (fwrap(angle + 45, 180) < 90)
+        {
+            bushY = true;
+            bushSlope = bushSlope * scaledW / scaledH;
+        }
+        else
+        {
+            bushY = false;
+            bushSlope = bushSlope * scaledH / scaledW;
+        }
+        // Invert the check when we switch from the y-axis to the x-axis
+        bushUnder = angle < 45 || angle >= 225;
+        
+        // Zoom and rotate the srcRect
+        FloatRect src = srcRect->toFloatRect();
+        src.x *= trans.getScale().x;
+        src.y *= trans.getScale().y;
+        src.w *= trans.getScale().x;
+        src.h *= trans.getScale().y;
+        
+        // We use a "left-handed" coordinate system, with positive y values being below the x-axis,
+        // so we need to use the negative of the angle to get the proper y values.
+        float rotation  = -angle * M_PI / 180.0f;
+        
+        // p1 doesn't change, so we can skip rotating it
+        Vec2 p1(src.x, src.y);
+        Vec2 p2 = rotate_point(p1, rotation, Vec2(src.x + src.w, src.y));
+        Vec2 p3 = rotate_point(p1, rotation, Vec2(src.x, src.y + src.h));
+        Vec2 p4 = rotate_point(p1, rotation, Vec2(src.x + src.w, src.y + src.h));
+        
+        // Find the upper boundary of the bush effect and rotate it back.
+        // The rotated slope is a horizontal line, so any x value will work.
+        Vec2 point(0, std::max(std::max(p1.y, p2.y), std::max(p3.y, p4.y)) - bushDepth);
+        point = rotate_point(p1, -rotation, point);
+        
+        // Unzoom the point and convert it into a percentage
+        point.y = point.y / trans.getScale().y / bitmap->height();
+        point.x = point.x / trans.getScale().x / bitmap->width();
+        
+        if (bushY)
+            bushIntercept = (point.y - (bushSlope * point.x));
+        else
+            bushIntercept = (point.x - (bushSlope * point.y));
     }
     
     void onSrcRectChange()
@@ -168,7 +245,7 @@ struct SpritePrivate
         quad.setTexRect(mirrored ? rect.hFlipped() : rect);
         
         quad.setPosRect(FloatRect(0, 0, rect.w, rect.h));
-        recomputeBushDepth();
+        bushDirty = true;
         
         wave.dirty = true;
     }
@@ -315,6 +392,9 @@ struct SpritePrivate
         }
         
         updateVisibility();
+        
+        if (isVisible && bushDirty)
+            recomputeBushDepth();
     }
 };
 
@@ -448,7 +528,7 @@ void Sprite::setZoomY(float value)
         return;
     
     p->trans.setScale(Vec2(getZoomX(), value));
-    p->recomputeBushDepth();
+    p->bushDirty = true;
     
     if (rgssVer >= 2)
         p->wave.dirty = true;
@@ -462,6 +542,8 @@ void Sprite::setAngle(float value)
         return;
     
     p->trans.setRotation(value);
+    
+    p->bushDirty = true;
 }
 
 void Sprite::setMirror(bool mirrored)
@@ -483,7 +565,7 @@ void Sprite::setBushDepth(int value)
         return;
     
     p->bushDepth = value;
-    p->recomputeBushDepth();
+    p->bushDirty = true;
 }
 
 void Sprite::setBlendType(int type)
@@ -602,7 +684,7 @@ void Sprite::draw()
         
         shader.setTone(p->tone->norm);
         shader.setOpacity(p->opacity.norm);
-        shader.setBushDepth(p->efBushDepth);
+        shader.setBushDepth(p->bushY, p->bushUnder, p->bushSlope, p->bushIntercept);
         shader.setBushOpacity(p->bushOpacity.norm);
         
         if (p->pattern && p->patternOpacity > 0) {

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -30,13 +30,16 @@
 static inline int
 wrapRange(int value, int min, int max)
 {
-	if (value >= min && value <= max)
+	if (value >= min && value < max)
 		return value;
 
-	while (value < min)
-		value += (max - min);
+	value -= min;
+	max -= min;
 
-	return value % (max - min);
+	while (value < 0)
+		value += max;
+
+	return (value % max) + min;
 }
 
 template<typename T>


### PR DESCRIPTION
Here we are. The big PR. Sorry for disappearing for a while, I burned myself out obsessing over trying to figure out a couple quirks in text rendering, and when I got back to it decided I really wanted to get this done.

Almost all RGSS features now support mega surfaces. The only exceptions are window_skins, which I figured wasn't needed, and radial_blur, which I took a look at recently and think I know how to handle it, but I want another break from working on this so that'll have to happen later. I did fix radial blurring on rectangles for normal bitmaps, though. I can split that into a separate PR if you want.

This PR includes #82, #98, #91, #145, #146, and #147.

As far as mkxp specific features go, I should be able to do animations without much issue, but my concern here was RGSS features so it was a little out of scope for me. I haven't even looked at sprite patterns but could probably handle it if there's demand for it. I think it should handle HiRes bitmaps reasonably well, although someone should probably decide if hires bitmaps should ever have the LoRes version drawn to because I think we have a few inconsistencies there.

The 32-bit pixman regions probably aren't really necessary, but I've seen warnings in the console about it before (from long text strings in the debug menu, which shouldn't happen anymore anyway) and it was an easy change.

I also fixed a small bug in hue_change, and disallowed negative zooms in sprites and planes. Partly because it matches RGSS behavior (sprites don't render at that point, and planes cause the game to hang. Probably because they get capped to 0, too, and then try to draw an infinite number of 0-pixel images).

And while I fully understand your desire for a test suite for this one, I really do want a break from this and making something to show off all of the potential edge cases I addressed isn't my idea of fun so expect it to be at least a few months before I get around to it.