### PR TITLE
Check for audioThreadTermReq in movie audio thread

### DIFF
--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -290,6 +290,9 @@ struct Movie
 
             // Periodically check the buffers until one is available
             while(true) {
+                // Quit if audio thread terminate request has been made
+                if (audioThreadTermReq) return;
+
                 alGetSourcei(audioSource, AL_BUFFERS_PROCESSED, &procBufs);
                 if(procBufs > 0) break;
                 SDL_Delay(AUDIO_SLEEP);


### PR DESCRIPTION
If you try to terminate the program or use the skip function during playback of a movie with audio, it would hang with endless errors messages similar to the following:

```[ALSOFT] (WW) Error generated on context 000001ec9422ee60, code 0xa001, "Invalid source ID 10"```

This happens because the audio thread is stuck in a while loop and trying to read from an OpenAL source that no longer exists. This PR fixes that.