### PR TITLE
Remove forced enabling of `enableBlitting` on macOS

### DIFF
--- a/mkxp.json
+++ b/mkxp.json
@@ -258,10 +258,10 @@
     // capable of it. Some drivers carry buggy
     // implementations of this functionality, so
     // disabling it can be used as a workaround.
-    // Does nothing on macOS. Force-disabled when
+    // Force-disabled when
     // smoothScaling or smoothScalingDown isn't
     // Nearest-Neighbor or Bilinear.
-    // (default: disabled)
+    // (default: disabled on windows, enabled on other systems)
     //
     // "enableBlitting": false,
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -530,12 +530,8 @@ static SDL_GLContext initGL(SDL_Window *win, Config &conf,
     return 0;
   }
 
-// This breaks scaling for Retina screens.
-// Using Metal should be rendering this irrelevant anyway, hopefully
-#ifndef MKXPZ_BUILD_XCODE
   if (!conf.enableBlitting)
     gl.BlitFramebuffer = 0;
-#endif
 
   gl.ClearColor(0, 0, 0, 1);
   gl.Clear(GL_COLOR_BUFFER_BIT);


### PR DESCRIPTION
On macOS, the `enableBlitting` config option would previously be enabled regardless of what the user put in mkxp.json because someone said it would break scaling on Retina displays.

I couldn't reproduce any such bug on a Retina display with any of the smooth scaling settings so this removes the forced enabling of `enableBlitting` on macOS.

Note that allowing `enableBlitting` to be disabled on macOS is required for most of the smooth scaling settings to work on macOS (see https://github.com/mkxp-z/mkxp-z/pull/100#issuecomment-1894431123).