### PR TITLE
Expose input bindings

### DIFF
--- a/binding/input-binding.cpp
+++ b/binding/input-binding.cpp
@@ -459,6 +459,12 @@ RB_METHOD(inputSaveBindings) {
     return Qnil;
 }
 
+RB_METHOD(inputResetBindings) {
+    BDescVec binds = genDefaultBindings(shState->config());
+	shState->rtData().bindingUpdateMsg.post(binds);
+    return Qnil;
+}
+
 RB_METHOD(inputClearLast) {
     shState->eThread().clearLastInput();
     return Qnil;
@@ -740,6 +746,7 @@ void inputBindingInit() {
     _rb_define_module_function(module, "bindings", inputGetBindings);
     _rb_define_module_function(module, "apply_bindings", inputApplyBindings);
     _rb_define_module_function(module, "save_bindings", inputSaveBindings);
+    _rb_define_module_function(module, "reset_bindings", inputResetBindings);
     
     if (rgssVer >= 3) {
         VALUE symHash = rb_hash_new();

--- a/src/eventthread.cpp
+++ b/src/eventthread.cpp
@@ -88,6 +88,7 @@ EventThread::ControllerState EventThread::controllerState;
 EventThread::MouseState EventThread::mouseState;
 EventThread::TouchState EventThread::touchState;
 SDL_atomic_t EventThread::verticalScrollDistance;
+SourceDesc lastInputDesc;
 
 /* User event codes */
 enum
@@ -407,7 +408,9 @@ void EventThread::process(RGSSThreadData &rtData)
                     break;
                 }
                 
-                keyStates[event.key.keysym.scancode] = true;
+                keyStates[event.key.keysym.scancode] = true;                
+                lastInputDesc.type = Key;
+                lastInputDesc.d.scan = event.key.keysym.scancode;
                 break;
                 
             case SDL_KEYUP :
@@ -426,6 +429,8 @@ void EventThread::process(RGSSThreadData &rtData)
                 
             case SDL_CONTROLLERBUTTONDOWN:
                 controllerState.buttons[event.cbutton.button] = true;
+                lastInputDesc.type = CButton;
+                lastInputDesc.d.cb = (SDL_GameControllerButton) event.cbutton.button;
                 break;
                 
             case SDL_CONTROLLERBUTTONUP:
@@ -434,6 +439,9 @@ void EventThread::process(RGSSThreadData &rtData)
                 
             case SDL_CONTROLLERAXISMOTION:
                 controllerState.axes[event.caxis.axis] = event.caxis.value;
+                lastInputDesc.type = CAxis;
+                lastInputDesc.d.ca.axis = (SDL_GameControllerAxis) event.caxis.axis;
+                lastInputDesc.d.ca.dir = event.caxis.value < 0 ? Negative : Positive;
                 break;
                 
             case SDL_CONTROLLERDEVICEADDED:
@@ -860,6 +868,16 @@ void EventThread::notifyGameScreenChange(const SDL_Rect &screen)
 void EventThread::lockText(bool lock)
 {
     lock ? SDL_LockMutex(textInputLock) : SDL_UnlockMutex(textInputLock);
+}
+
+const SourceDesc EventThread::getLastInput()
+{
+    return lastInputDesc;
+}
+
+void EventThread::clearLastInput()
+{
+    lastInputDesc.type = Invalid;
 }
 
 void SyncPoint::haltThreads()

--- a/src/eventthread.h
+++ b/src/eventthread.h
@@ -117,6 +117,9 @@ public:
 	/* Called on game screen (size / offset) changes */
 	void notifyGameScreenChange(const SDL_Rect &screen);
 
+	const SourceDesc getLastInput();
+	void clearLastInput();
+
 private:
 	static int eventFilter(void *, SDL_Event*);
 

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -28,7 +28,6 @@
 #include "util/util.h"
 
 #include <SDL_scancode.h>
-#include <SDL_keyboard.h>
 #include <SDL_mouse.h>
 #include <SDL_clipboard.h>
 

--- a/src/input/input.h
+++ b/src/input/input.h
@@ -24,6 +24,7 @@
 
 #include <unordered_map>
 #include <SDL_gamecontroller.h>
+#include <SDL_keyboard.h>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
mkxp has a settings menu designed to replace RPG Maker's F1 menu for configuring input bindings. This is nice as a once-size-fits-all solution when using mkxp to run any game. Those developing their games with mkxp in mind may want to implement an input configuration in-game. This PR exposes binding read/write functionality to serve that purpose. Additionally, the last detected input event is stored in the event thread for convenience. The following API calls have been added (if this gets merged, this is information that should be added to the wiki):

- `Input.last` will return an array with information of the very last input detected.
  - Axis information will be a string in the format of `axis_foo+` or `axis_foo-`. The `axis_` prefix indicates the type, the last character indicates the direction, and `foo` is the SDL-recognized name of the axis.
  - Gamepad button information will be a string in the format of `pad_bar` where the `pad_` prefix indicates the type, and `bar` is the SDL-recognized name of the button.
  - Keyboard input names have no prefix and are the SDL-recognized names of scancodes.
- `Input.clear_last` will clear the last detected input.
- `Input.bindings(key_name)` will return an array of bindings for the requested `key_name`. Each entry if any will use the same format as what is returned by `Input.last`.
- `Input.apply_bindings(key_name, bindings)` applies the provided `bindings` for the `key_name`, updating what mkxp will register for inputs. `bindings` is an array where each element has the same format as what is returned by `Input.last`.
- `Input.save_bindings` writes the current active settings to the disk. This is the same as when you save these inputs using the settings menu.
- `Input.reset_bindings` serves the same purpose as the reset button in the settings menu; it resets all input bindings to their default values.

Example of a configuration that might define these input values for the developer to work with:
```
  "input": {
	"A": ["Left Shift", "pad_x"],
	"B": ["Escape", "Keypad 0", "X", "pad_b"],
	"C": ["Space", "Return", "Z", "pad_a"],
	"X": ["A", "pad_y"],
	"Y": ["S", "pad_leftstick"],
	"Z": ["D", "pad_rightstick"],
	"L": ["Q", "pad_leftshoulder"],
	"R": ["W", "pad_rightshoulder"],
	"UP": ["Up", "pad_dpup", "axis_lefty-"],
	"DOWN": ["Down", "pad_dpdown", "axis_lefty+"],
	"LEFT": ["Left", "pad_dpleft", "axis_leftx-"],
	"RIGHT": ["Right", "pad_dpright", "axis_leftx+"]
  }
```