### PR TITLE
Add mipmap scaling

### DIFF
--- a/mkxp.json
+++ b/mkxp.json
@@ -89,6 +89,13 @@
     // "smoothScaling": 0,
 
 
+    // Apply mipmap interpolation when game screen
+    // is downscaled
+    // (default: false)
+    //
+    // "smoothScalingMipmaps": false,
+
+
     // Sharpness when using Bicubic scaling.
     // A good starting range is 0 to 100,
     // but you may wish to go outside that range in either direction.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -135,6 +135,7 @@ void Config::read(int argc, char *argv[]) {
         {"fullscreen", false},
         {"fixedAspectRatio", true},
         {"smoothScaling", 0},
+        {"smoothScalingMipmaps", false},
         {"bicubicSharpness", 100},
 #ifdef MKXPZ_SSL
         {"xbrzScalingFactor", 1.},
@@ -269,6 +270,7 @@ try { exp } catch (...) {}
     SET_OPT(fullscreen, boolean);
     SET_OPT(fixedAspectRatio, boolean);
     SET_OPT(smoothScaling, integer);
+    SET_OPT(smoothScalingMipmaps, boolean);
     SET_OPT(bicubicSharpness, integer);
 #ifdef MKXPZ_SSL
     SET_OPT(xbrzScalingFactor, integer);

--- a/src/config.h
+++ b/src/config.h
@@ -44,6 +44,7 @@ struct Config {
     bool fullscreen;
     bool fixedAspectRatio;
     int smoothScaling;
+    bool smoothScalingMipmaps;
     int bicubicSharpness;
 #ifdef MKXPZ_SSL
     double xbrzScalingFactor;

--- a/src/display/gl/gl-fun.h
+++ b/src/display/gl/gl-fun.h
@@ -54,6 +54,8 @@ typedef void (APIENTRYP _PFNGLTEXIMAGE2DPROC) (GLenum target, GLint level, GLint
 typedef void (APIENTRYP _PFNGLTEXSUBIMAGE2DPROC) (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const GLvoid *pixels);
 typedef void (APIENTRYP _PFNGLTEXPARAMETERIPROC) (GLenum target, GLenum pname, GLint param);
 typedef void (APIENTRYP _PFNGLACTIVETEXTUREPROC) (GLenum texture);
+typedef void (APIENTRYP _PFNGLGENERATEMIPMAPPROC) (GLenum target);
+typedef void (APIENTRYP _PFNGLGENERATETEXTUREMIPMAPPROC) (GLuint texture);
 
 /* Debugging */
 typedef void (APIENTRY * _GLDEBUGPROC) (GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void *userParam);
@@ -148,6 +150,8 @@ typedef void (APIENTRYP _PFNGLRELEASESHADERCOMPILERPROC) (void);
 	GL_FUN(TexSubImage2D, _PFNGLTEXSUBIMAGE2DPROC) \
 	GL_FUN(TexParameteri, _PFNGLTEXPARAMETERIPROC) \
 	GL_FUN(ActiveTexture, _PFNGLACTIVETEXTUREPROC) \
+	GL_FUN(GenerateMipmap, _PFNGLGENERATEMIPMAPPROC) \
+	GL_FUN(GenerateTextureMipmap, _PFNGLGENERATETEXTUREMIPMAPPROC) \
 	/* Buffer object */ \
 	GL_FUN(GenBuffers, _PFNGLGENBUFFERSPROC) \
 	GL_FUN(DeleteBuffers, _PFNGLDELETEBUFFERSPROC) \

--- a/src/display/gl/gl-util.h
+++ b/src/display/gl/gl-util.h
@@ -24,6 +24,8 @@
 
 #include "gl-fun.h"
 #include "etc-internal.h"
+#include "sharedstate.h"
+#include "config.h"
 
 /* Struct wrapping GLuint for some light type safety */
 #define DEF_GL_ID \
@@ -99,7 +101,13 @@ namespace TEX
 
 	static inline void setSmooth(bool mode)
 	{
-		gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mode ? GL_LINEAR : GL_NEAREST);
+		if (mode && shState->config().smoothScalingMipmaps) {
+			gl.GenerateMipmap(GL_TEXTURE_2D);
+			gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+		} else {
+			gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mode ? GL_LINEAR : GL_NEAREST);
+		}
+
 		gl.TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, mode ? GL_LINEAR : GL_NEAREST);
 	}
 }


### PR DESCRIPTION
Yields a substantial quality improvement when the window is much smaller than the rendered resolution.

Bilinear+Mipmap is much faster than Lanczos3 (tested when downscaling from 4800p to 2160p), and also looks much better to me. Performance numbers at the title screen:

* Lanczos3: 20 fps
* Bilinear: 35 fps
* Bilinear+Mipmap: 32 fps

Once this is merged, the "Performance Tips" documentation should be amended to suggest disabling mipmap scaling.