### PR TITLE
Added support for replacing game scripts

### DIFF
--- a/binding/binding-mri.cpp
+++ b/binding/binding-mri.cpp
@@ -854,6 +854,34 @@ static VALUE evalString(VALUE string, VALUE filename, int *state) {
     return rb_protect((VALUE(*)(VALUE))evalHelper, (VALUE)&arg, state);
 }
 
+static VALUE findReplacedScript(long index, VALUE name, VALUE script) {
+    std::string scriptName = rb_string_value_cstr(&name);
+    std::string indexKey = std::to_string(index);
+    std::string scriptReplacement = "";
+    std::string scriptData = "";
+    
+    const Config &conf = shState->rtData().config;
+    auto &replacements = conf.replaceScripts;
+    for (auto it : replacements) {
+        if (it.first == indexKey || it.first == scriptName) {
+            scriptReplacement = it.second;
+            break;
+        }
+    }
+    
+    if (scriptReplacement.empty()) {
+        return RUBY_Qnil;
+    }
+    
+    if (!readFileSDL(scriptReplacement.c_str(), scriptData)) {
+        showMsg(std::string("Unable to open '") + scriptReplacement + "'");
+        return RUBY_Qnil;
+    }
+    
+    VALUE ret = newStringUTF8(scriptData.c_str(), scriptData.size());
+    return ret;
+}
+
 static void runCustomScript(const std::string &filename) {
     std::string scriptData;
     
@@ -929,6 +957,12 @@ static void runRMXPScripts(BacktraceData &btData) {
         
         VALUE scriptName = rb_ary_entry(script, 1);
         VALUE scriptString = rb_ary_entry(script, 2);
+        VALUE replacedScript = findReplacedScript(i, scriptName, scriptString);
+        
+        if (replacedScript != RUBY_Qnil) {
+            rb_ary_store(script, 3, replacedScript);
+            continue;
+        }
         
         int result = Z_OK;
         unsigned long bufferLen;

--- a/mkxp.json
+++ b/mkxp.json
@@ -341,6 +341,17 @@
     // "customScript": "/path/to/script.rb",
 
 
+    // Replace game scripts with custom scripts.
+    // Game script may be identified either by its index in
+    // the script list or by the script name (must match exactly)
+    // (default: none)
+    //
+    // "replaceScripts": {
+    //     "123": "path/to/script.rb",
+    //     "Scene_Title": "path/to/script.rb"
+    // },
+
+
     // Define raw scripts (e.g. compatibility wrappers)
     // to be executed before the actual Scripts.rxdata
     // execution starts

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -84,6 +84,25 @@ bool copyObject(json::value &dest, json::value &src, const char *objectName = ""
     return true;
 }
 
+bool copyObjectToMap(std::map<std::string, std::string> &dest, json::value &src, const char *objectName = "") {
+    if (src.is_null())
+        return false;
+    
+    if (!src.is_object())
+        return false;
+    
+    auto &srcVec = src.as_object();
+    
+    for (auto it : srcVec) {
+        if (it.second.is_string()) {
+            dest[it.first] = it.second.as_string();
+        } else {
+            Debug() << "Invalid variable in configuration:" << objectName << it.first;
+        }
+    }
+    return true;
+}
+
 bool getEnvironmentBool(const char *env, bool defaultValue) {
     const char *e = SDL_getenv(env);
     if (!e)
@@ -185,6 +204,7 @@ void Config::read(int argc, char *argv[]) {
         {"pathCache", true},
         {"useScriptNames", true},
         {"preloadScript", json::array({})},
+        {"replaceScripts", json::object({})},
         {"RTP", json::array({})},
         {"patches", json::array({})},
         {"fontSub", json::array({})},
@@ -310,6 +330,8 @@ try { exp } catch (...) {}
     SET_STRINGOPT(customScript, customScript);
     SET_OPT(useScriptNames, boolean);
     SET_OPT(dumpAtlas, boolean);
+    
+    copyObjectToMap(replaceScripts, baseConf.as_object()["replaceScripts"], "replaceScripts .");
     
     fillStringVec(opts["preloadScript"], preloadScripts);
     fillStringVec(opts["RTP"], rtps);

--- a/src/config.h
+++ b/src/config.h
@@ -109,6 +109,8 @@ struct Config {
     
     std::string customScript;
     
+    std::map<std::string, std::string> replaceScripts;
+    
     std::vector<std::string> launchArgs;
     std::vector<std::string> preloadScripts;
     std::vector<std::string> rtps;


### PR DESCRIPTION
Script replacements are configured with a new "replaceScripts" option in `mkxp.json`. Because you can have multiple scripts with the same names you can also specify using the script index instead. 