### PR TITLE
Log expensive optional operations

### DIFF
--- a/src/display/tilemapvx.cpp
+++ b/src/display/tilemapvx.cpp
@@ -21,6 +21,8 @@
 
 #include "tilemapvx.h"
 
+#include "util/debugwriter.h"
+
 #include "tileatlasvx.h"
 #include "etc-internal.h"
 #include "bitmap.h"
@@ -201,6 +203,8 @@ struct TilemapVXPrivate : public ViewportElement, TileAtlasVX::Reader
 
 		if (shState->config().dumpAtlas)
 		{
+			Debug() << "Dumping tile atlas...";
+
 			Bitmap dump(atlas);
 			if (dump.hasHires())
 			{
@@ -210,6 +214,8 @@ struct TilemapVXPrivate : public ViewportElement, TileAtlasVX::Reader
 			{
 				dump.saveToFile("dumped_atlas.png");
 			}
+
+			Debug() << "Tile atlas dump completed.";
 		}
 	}
 

--- a/src/display/tilemapvx.cpp
+++ b/src/display/tilemapvx.cpp
@@ -202,10 +202,13 @@ struct TilemapVXPrivate : public ViewportElement, TileAtlasVX::Reader
 		if (shState->config().dumpAtlas)
 		{
 			Bitmap dump(atlas);
-			dump.saveToFile("dumped_atlas.png");
 			if (dump.hasHires())
 			{
 				dump.getHires()->saveToFile("dumped_atlas_hires.png");
+			}
+			else
+			{
+				dump.saveToFile("dumped_atlas.png");
 			}
 		}
 	}

--- a/src/filesystem/filesystem.cpp
+++ b/src/filesystem/filesystem.cpp
@@ -439,11 +439,15 @@ static PHYSFS_EnumerateCallbackResult cacheEnumCB(void *d, const char *origdir,
 }
 
 void FileSystem::createPathCache() {
+  Debug() << "Loading path cache...";
+
   CacheEnumData data(p);
   data.fileLists.push(&p->fileLists[""]);
   PHYSFS_enumerate("", cacheEnumCB, &data);
 
   p->havePathCache = true;
+
+  Debug() << "Path cache completed.";
 }
 
 void FileSystem::reloadPathCache() {


### PR DESCRIPTION
Path caching and atlas dumping incur a nontrivial performance hit, so it's useful to log that they're happening so that users are reminded to disable them if they were enabled accidentally.

Also avoid dumping an empty lores atlas if only the hires atlas exists.