### PR TITLE
Fix a segfault in audio streams

### DIFF
--- a/src/audio/aldatasource.h
+++ b/src/audio/aldatasource.h
@@ -56,8 +56,7 @@ struct ALDataSource
 ALDataSource *createSDLSource(SDL_RWops &ops,
                               const char *extension,
 			                  uint32_t maxBufSize,
-			                  bool looped,
-			                  int fallbackMode);
+			                  bool looped);
 
 ALDataSource *createVorbisSource(SDL_RWops &ops,
                                  bool looped);

--- a/src/audio/alstream.cpp
+++ b/src/audio/alstream.cpp
@@ -90,18 +90,7 @@ void ALStream::close()
 
 void ALStream::open(const std::string &filename)
 {
-	checkStopped();
-
-	switch (state)
-	{
-	case Playing:
-	case Paused:
-		stopStream();
-	case Stopped:
-		closeSource();
-	case Closed:
-		openSource(filename);
-	}
+	openSource(filename);
 
 	state = Stopped;
 }
@@ -201,32 +190,27 @@ void ALStream::closeSource()
 
 struct ALStreamOpenHandler : FileSystem::OpenHandler
 {
-	SDL_RWops *srcOps;
 	bool looped;
 	ALDataSource *source;
 	int fallbackMode;
 	std::string errorMsg;
 
-	ALStreamOpenHandler(SDL_RWops &srcOps, bool looped)
-	    : srcOps(&srcOps), looped(looped), source(0), fallbackMode(0)
+	ALStreamOpenHandler(bool looped)
+	    : looped(looped), source(0), fallbackMode(0)
 	{}
 
 	bool tryRead(SDL_RWops &ops, const char *ext)
 	{
-		/* Copy this because we need to keep it around,
-		 * as we will continue reading data from it later */
-		*srcOps = ops;
-
 		/* Try to read ogg file signature */
 		char sig[5] = { 0 };
-		SDL_RWread(srcOps, sig, 1, 4);
-		SDL_RWseek(srcOps, 0, RW_SEEK_SET);
+		SDL_RWread(&ops, sig, 1, 4);
+		SDL_RWseek(&ops, 0, RW_SEEK_SET);
 
 		try
 		{
 			if (!strcmp(sig, "OggS"))
 			{
-				source = createVorbisSource(*srcOps, looped);
+				source = createVorbisSource(ops, looped);
 				return true;
 			}
 
@@ -236,12 +220,12 @@ struct ALStreamOpenHandler : FileSystem::OpenHandler
 
 				if (HAVE_FLUID)
 				{
-					source = createMidiSource(*srcOps, looped);
+					source = createMidiSource(ops, looped);
 					return true;
 				}
 			}
 
-			source = createSDLSource(*srcOps, ext, STREAM_BUF_SIZE, looped, fallbackMode);
+			source = createSDLSource(ops, ext, STREAM_BUF_SIZE, looped, fallbackMode);
 		}
 		catch (const Exception &e)
 		{
@@ -257,21 +241,31 @@ struct ALStreamOpenHandler : FileSystem::OpenHandler
 
 void ALStream::openSource(const std::string &filename)
 {
-	ALStreamOpenHandler handler(srcOps, looped);
-	shState->fileSystem().openRead(handler, filename.c_str());
-	source = handler.source;
-	needsRewind.clear();
+	ALStreamOpenHandler handler(looped);
+	try
+	{
+		shState->fileSystem().openRead(handler, filename.c_str());
+	} catch (const Exception &e)
+	{
+		/* If no file was found then we leave the stream open.
+		 * A PHYSFSError means we found a match but couldn't
+		 * open the file, so we'll close it in that case. */
+		if (e.type != Exception::NoFileError)
+			close();
+		
+		throw e;
+	}
+
+	close();
 
 	// Try fallback mode, e.g. for handling S32->F32 sample format conversion
-	if (!source)
+	if (!handler.source)
 	{
 		handler.fallbackMode = 1;
 		shState->fileSystem().openRead(handler, filename.c_str());
-		source = handler.source;
-		needsRewind.clear();
 	}
 
-	if (!source)
+	if (!handler.source)
 	{
 		char buf[512];
 		snprintf(buf, sizeof(buf), "Unable to decode audio stream: %s: %s",
@@ -279,6 +273,9 @@ void ALStream::openSource(const std::string &filename)
 
 		Debug() << buf;
 	}
+	
+	source = handler.source;
+	needsRewind.clear();
 }
 
 void ALStream::stopStream()

--- a/src/audio/alstream.cpp
+++ b/src/audio/alstream.cpp
@@ -192,11 +192,10 @@ struct ALStreamOpenHandler : FileSystem::OpenHandler
 {
 	bool looped;
 	ALDataSource *source;
-	int fallbackMode;
 	std::string errorMsg;
 
 	ALStreamOpenHandler(bool looped)
-	    : looped(looped), source(0), fallbackMode(0)
+	    : looped(looped), source(0)
 	{}
 
 	bool tryRead(SDL_RWops &ops, const char *ext)
@@ -225,7 +224,7 @@ struct ALStreamOpenHandler : FileSystem::OpenHandler
 				}
 			}
 
-			source = createSDLSource(ops, ext, STREAM_BUF_SIZE, looped, fallbackMode);
+			source = createSDLSource(ops, ext, STREAM_BUF_SIZE, looped);
 		}
 		catch (const Exception &e)
 		{
@@ -257,13 +256,6 @@ void ALStream::openSource(const std::string &filename)
 	}
 
 	close();
-
-	// Try fallback mode, e.g. for handling S32->F32 sample format conversion
-	if (!handler.source)
-	{
-		handler.fallbackMode = 1;
-		shState->fileSystem().openRead(handler, filename.c_str());
-	}
 
 	if (!handler.source)
 	{

--- a/src/audio/alstream.h
+++ b/src/audio/alstream.h
@@ -74,8 +74,6 @@ struct ALStream
 	uint64_t procFrames;
 	AL::Buffer::ID lastBuf;
 
-	SDL_RWops srcOps;
-
 	struct
 	{
 		ALenum format;

--- a/src/audio/audiostream.cpp
+++ b/src/audio/audiostream.cpp
@@ -113,31 +113,26 @@ void AudioStream::play(const std::string &filename,
 	/* Requested audio file is different from current one */
 	bool diffFile = (filename != current.filename);
 
-	switch (sState)
+	if (diffFile || sState == ALStream::Closed)
 	{
-	case ALStream::Paused :
-	case ALStream::Playing :
-		stream.stop();
-	case ALStream::Stopped :
-		if (diffFile)
-			stream.close();
-	case ALStream::Closed :
-		if (diffFile)
+		try
 		{
-			try
-			{
-				/* This will throw on errors while
-				 * opening the data source */
-				stream.open(filename);
-			}
-			catch (const Exception &e)
-			{
-				unlockStream();
-				throw e;
-			}
+			/* This will throw on errors while
+			 * opening the data source */
+			stream.open(filename);
 		}
-
-		break;
+		catch (const Exception &e)
+		{
+			unlockStream();
+			throw e;
+		}
+	} else {
+		switch (sState)
+		{
+			case ALStream::Paused :
+			case ALStream::Playing :
+				stream.stop();
+		}
 	}
 
 	setVolume(Base, _volume);

--- a/src/audio/midisource.cpp
+++ b/src/audio/midisource.cpp
@@ -631,15 +631,9 @@ struct MidiSource : ALDataSource, MidiReadHandler
 			throw Exception(Exception::MKXPError, "Reading midi data failed");
 		}
 
-		try
-		{
-			readMidi(this, data);
-		}
-		catch (const Exception &)
-		{
-			SDL_RWclose(&ops);
-			throw;
-		}
+		SDL_RWclose(&ops);
+
+		readMidi(this, data);
 
 		synth = shState->midiState().allocateSynth();
 

--- a/src/audio/sdlsoundsource.cpp
+++ b/src/audio/sdlsoundsource.cpp
@@ -27,7 +27,7 @@
 struct SDLSoundSource : ALDataSource
 {
 	Sound_Sample *sample;
-	SDL_RWops &srcOps;
+	SDL_RWops srcOps;
 	uint8_t sampleSize;
 	bool looped;
 

--- a/src/audio/vorbissource.cpp
+++ b/src/audio/vorbissource.cpp
@@ -53,7 +53,7 @@ static ov_callbacks OvCallbacks =
 
 struct VorbisSource : ALDataSource
 {
-	SDL_RWops &src;
+	SDL_RWops src;
 
 	OggVorbis_File vf;
 


### PR DESCRIPTION
We're currently closing audio streams as soon as the game attempts to open a new one. In the event that this fails, and then the next audio opened is the same as last successful attempt, we segfault. RGSS doesn't close the stream unless the attempt was successful, so I'm fixing the crash by doing that as well. Incidentally, I didn't actually see a game do that, I was just screwing around with something that ended up triggering it.

While I was poking around in the code I also saw that file handles for midi files were only closed if it errored, so that's fixed, too.