### PR TITLE
Add `defInternalScreen` to config

### DIFF
--- a/mkxp.json
+++ b/mkxp.json
@@ -169,10 +169,27 @@
     // "vsync": false,
 
 
+    // Specify the internal screen width on startup.
+    // If set to 0, it will default to the default
+    // resolution width specific to the RGSS version.
+    // (640 in RGSS1, 544 in RGSS2 or higher)
+    // (default: 0)
+    //
+    // "defInternalScreenW": 640,
+
+
+    // Specify the internal screen height on startup.
+    // If set to 0, it will default to the default
+    // resolution height specific to the RGSS version.
+    // (480 in RGSS1, 416 in RGSS2 or higher)
+    // (default: 0)
+    //
+    // "defInternalScreenH": 480,
+
+
     // Specify the window width on startup. If set to 0,
     // it will default to the default resolution width
-    // specific to the RGSS version (640 in RGSS1, 544
-    // in RGSS2 or higher).
+    // (Refer to defInternalScreenW)
     // (default: 0)
     //
     // "defScreenW": 640,
@@ -180,8 +197,7 @@
 
     // Specify the window height on startup. If set to 0,
     // it will default to the default resolution height
-    // specific to the RGSS version (480 in RGSS1, 416
-    // in RGSS2 or higher).
+    // (Refer to defInternalScreenH)
     // (default: 0)
     //
     // "defScreenH": 480,

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -148,6 +148,8 @@ void Config::read(int argc, char *argv[]) {
         {"framebufferScalingFactor", 1.},
         {"atlasScalingFactor", 1.},
         {"vsync", false},
+        {"defInternalScreenW", 0},
+        {"defInternalScreenH", 0},
         {"defScreenW", 0},
         {"defScreenH", 0},
         {"windowTitle", ""},
@@ -250,6 +252,8 @@ try { exp } catch (...) {}
     SET_OPT_CUSTOMKEY(jit.minCalls, JITMinCalls, integer);
     SET_OPT_CUSTOMKEY(yjit.enabled, YJITEnable, boolean);
     SET_OPT(rgssVersion, integer);
+    SET_OPT(defInternalScreenW, integer);
+    SET_OPT(defInternalScreenH, integer);
     SET_OPT(defScreenW, integer);
     SET_OPT(defScreenH, integer);
     
@@ -359,11 +363,17 @@ try { exp } catch (...) {}
 }
 
 static void setupScreenSize(Config &conf) {
+    if (conf.defInternalScreenW <= 0)
+        conf.defInternalScreenW = (conf.rgssVersion == 1 ? 640 : 544);
+    
+    if (conf.defInternalScreenH <= 0)
+        conf.defInternalScreenH = (conf.rgssVersion == 1 ? 480 : 416);
+    
     if (conf.defScreenW <= 0)
-        conf.defScreenW = (conf.rgssVersion == 1 ? 640 : 544);
+        conf.defScreenW = conf.defInternalScreenW;
     
     if (conf.defScreenH <= 0)
-        conf.defScreenH = (conf.rgssVersion == 1 ? 480 : 416);
+        conf.defScreenH = conf.defInternalScreenH;
 }
 
 bool Config::fontIsSolid(const char *fontName) const {

--- a/src/config.h
+++ b/src/config.h
@@ -58,6 +58,8 @@ struct Config {
     double atlasScalingFactor;
     bool vsync;
     
+    int defInternalScreenW;
+    int defInternalScreenH;
     int defScreenW;
     int defScreenH;
     std::string windowTitle;

--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -66,9 +66,6 @@
 #include <climits>
 
 
-#define DEF_SCREEN_W (rgssVer == 1 ? 640 : 544)
-#define DEF_SCREEN_H (rgssVer == 1 ? 480 : 416)
-
 #define DEF_FRAMERATE (rgssVer == 1 ? 40 : 60)
 
 #define DEF_MAX_VIDEO_FRAMES 30
@@ -834,9 +831,9 @@ struct GraphicsPrivate {
     IntruList<Disposable> dispList;
     
     GraphicsPrivate(RGSSThreadData *rtData)
-    : scResLores(DEF_SCREEN_W, DEF_SCREEN_H),
-    scRes(rtData->config.enableHires ? (int)lround(rtData->config.framebufferScalingFactor * DEF_SCREEN_W) : DEF_SCREEN_W,
-        rtData->config.enableHires ? (int)lround(rtData->config.framebufferScalingFactor * DEF_SCREEN_H) : DEF_SCREEN_H),
+    : scResLores(rtData->config.defInternalScreenW, rtData->config.defInternalScreenH),
+    scRes(rtData->config.enableHires ? (int)lround(rtData->config.framebufferScalingFactor * rtData->config.defInternalScreenW) : rtData->config.defInternalScreenW,
+        rtData->config.enableHires ? (int)lround(rtData->config.framebufferScalingFactor * rtData->config.defInternalScreenH) : rtData->config.defInternalScreenH),
     scSize(scRes),
     winSize(rtData->config.defScreenW, rtData->config.defScreenH),
     screen(scRes.x, scRes.y), threadData(rtData),


### PR DESCRIPTION
Currently, although you can change the default window size in the config, there's no way to do the same with the initial internal screen resolution, and you *had* to do the latter within RGSS even after doing the former within the config.

I found that insane, so this adds `defInternalScreenH` and `defInternalScreenW` options. This should probably be equivalent to running `Graphics.resize_screen` on startup.

On top of that, if `defInternalScreenH/W` is set but `defScreenH/W` isn't, it defaults the window size to the internal screen's resolution.

In a perfect world, the config option to change the SDL window's size would be `defWindowH/W` so this would be `defScreenH/W` and everything would have a consistent naming scheme with `resize_window` vs `resize_screen`, but it's *way* too late for that