### PR TITLE
Update mac-os workflow to use Xcode 14

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -250,6 +250,10 @@ jobs:
         with:
           length: 7
 
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '14.3.1'
+
       - name: Remove pre-existing homebrew packages
         run: brew remove --force $(brew list)
 


### PR DESCRIPTION
Right now, the MacOS automatic build fails with `ld: unknown options: -force_cpusubtype_ALL` while building vorbis. And based on https://trac.macports.org/ticket/68240, this is an issue introduced by Xcode 15 no longer accepting `-force_cpusubtype_ALL` as a valid flag.

So anyways, this just slaps "use Xcode 14 pls" onto the workflow and calls it a day.

![1720624420378__()](https://github.com/mkxp-z/mkxp-z/assets/46246438/87d23a6d-69de-4708-bffa-b8f91656f497)
Which works, according to my [quick tests](https://github.com/PieGodEX/mkxp-z/actions/runs/9866500459)

Alternate solutions probably exist, like
- "just downgrade the runner to `macos-13`"
- "just remove the flag from the fork", or
- ~~"just update the vorbis fork since they fixed that on their side by now"~~ (EDIT: never mind no they didn't)

But this is probably the easiest and most future-proof way with the least chance of accidentally affecting something else.