### PR TITLE
Fix build on arm64 Fedora Linux 40

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -221,7 +221,8 @@ $(DOWNLOADS)/sdl2_image/cmakebuild/Makefile: $(DOWNLOADS)/sdl2_image/CMakeLists.
 	-DSDL2IMAGE_JPG_SHARED=no \
 	-DSDL2IMAGE_JXL=yes \
 	-DSDL2IMAGE_JXL_SHARED=no \
-	-DSDL2IMAGE_VENDORED=yes
+	-DSDL2IMAGE_VENDORED=yes \
+	-DSDL2IMAGE_SAMPLES=no
 
 $(DOWNLOADS)/sdl2_image/CMakeLists.txt:
 	$(CLONE) $(GITHUB)/mkxp-z/SDL_image $(DOWNLOADS)/sdl2_image -b mkxp-z; \


### PR DESCRIPTION
Building Linux dependencies would fail because of one of the SDL_image samples.

    [ 96%] Built target SDL2_image
    [100%] Linking CXX executable showanim
    /usr/bin/ld: build-aarch64/lib64/libSDL2.a(SDL_dynapi.c.o): relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `stderr@@GLIBC_2.17' which may bind externally can not be used when making a shared object; recompile with -fPIC
    /usr/bin/ld: build-aarch64/lib64/libSDL2.a(SDL_dynapi.c.o)(.text+0x26f4): unresolvable R_AARCH64_ADR_PREL_PG_HI21 relocation against symbol `stderr@@GLIBC_2.17'
    /usr/bin/ld: final link failed: bad value
    collect2: error: ld returned 1 exit status
    make[3]: *** [CMakeFiles/showanim.dir/build.make:104: showanim] Error 1
    make[2]: *** [CMakeFiles/Makefile2:458: CMakeFiles/showanim.dir/all] Error 2
    make[1]: *** [Makefile:136: all] Error 2

This pull request fixes this by not building the SDL_image samples. These samples are not required to build mkxp-z.