### PR TITLE
Allow symlinks by default

### DIFF
--- a/mkxp.json
+++ b/mkxp.json
@@ -325,9 +325,9 @@
 
 
     // Allow symlinks for game assets to be followed
-    // (default: disabled)
+    // (default: enabled)
     //
-    // "allowSymlinks": false,
+    // "allowSymlinks": true,
 
 
     // Organisation / company and application / game

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -173,7 +173,7 @@ void Config::read(int argc, char *argv[]) {
         {"anyAltToggleFS", false},
         {"enableReset", true},
         {"enableSettings", true},
-        {"allowSymlinks", false},
+        {"allowSymlinks", true},
         {"dataPathOrg", ""},
         {"dataPathApp", ""},
         {"iconPath", ""},


### PR DESCRIPTION
PhysicsFS supports disabling symlinks, but this is intended for environments where scripts are sandboxed. Since mkxp-z runs Ruby code unsandboxed, this doesn't yield any practical security benefit for us.