### PR TITLE
Remove framerate restrictions

### DIFF
--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -1358,7 +1358,7 @@ DEF_ATTR_RD_SIMPLE(Graphics, FrameRate, int, p->frameRate)
 DEF_ATTR_SIMPLE(Graphics, FrameCount, int, p->frameCount)
 
 void Graphics::setFrameRate(int value) {
-    p->frameRate = clamp(value, 10, 120);
+    p->frameRate = std::max(value, 1);
     
     if (p->threadData->config.syncToRefreshrate)
         return;


### PR DESCRIPTION
If game devs want to use framerates outside of Enterbrain's arbitrary restrictions, there's no reason for us to prevent it. Same reason we don't restrict the resolution.

When this is merged, the wiki should be updated accordingly.

Fixes https://github.com/mkxp-z/mkxp-z/issues/64