### PR TITLE
Fix controller bindings

### DIFF
--- a/src/settingsmenu.cpp
+++ b/src/settingsmenu.cpp
@@ -1027,7 +1027,7 @@ bool SettingsMenu::onEvent(const SDL_Event &event)
 			return false;
 		break;
 
-	case SDL_JOYBUTTONDOWN :
+	case SDL_CONTROLLERBUTTONDOWN :
 	case SDL_CONTROLLERBUTTONUP :
 	case SDL_CONTROLLERAXISMOTION :
 		if (!p->hasFocus)


### PR DESCRIPTION
For over two years it has been impossible to bind controller buttons to mkxp-z keys in the F1 menu. Most of the keys were just ignored by the menu and were processed by the game instead.

After building many legacy mkxp-z builds I found out the issue existed since this refactoring: https://github.com/mkxp-z/mkxp-z/commit/5f4b644bd0317a19f92e5e0e205c997c5d5e99a1 https://github.com/mkxp-z/mkxp-z/commit/f839001be9a2538e3997f3e9d6b36c516a96d84e https://github.com/mkxp-z/mkxp-z/commit/77fce74b93e4c4e155f7b90a6c184c301ef913bd

The cause of the issue was the one forgotten `SDL_JOYBUTTONDOWN` which needs to be replaced with `SDL_CONTROLLERBUTTONDOWN`.