### PR TITLE
Fix armv7 cross-compile target

### DIFF
--- a/linux/meson-armv7.txt
+++ b/linux/meson-armv7.txt
@@ -9,5 +9,5 @@ cmake = 'cmake'
 [host_machine]
 system = 'linux'
 cpu_family = 'arm'
-cpu = 'generic-armv7-a+fp'
+cpu = 'generic-armv7-a+vfpv3-d16'
 endian = 'little'

--- a/linux/target-armv7.sh
+++ b/linux/target-armv7.sh
@@ -21,7 +21,7 @@
 
 export ARCH=armv7
 export ARCH_OPENSSL=armv4
-export ARCH_CFLAGS="-mcpu=generic-armv7-a+fp -mtune=generic-armv7-a+fp"
+export ARCH_CFLAGS="-mcpu=generic-armv7-a+vfpv3-d16 -mtune=generic-armv7-a+vfpv3-d16"
 export ARCH_CONFIGURE=arm-linux-gnueabihf
 export CC="$ARCH_CONFIGURE-gcc"
 export ARCH_CMAKE_TOOLCHAIN=toolchain-arm32.cmake


### PR DESCRIPTION
I don't know why this change matters; my reading of the GCC documentation is that they should be equivalent, but clearly either I misread the docs or there's a GCC bug. Either way, this fix should be fine.