### PR TITLE
Fix armv6 cross-compile target

### DIFF
--- a/linux/meson-armv6.txt
+++ b/linux/meson-armv6.txt
@@ -9,5 +9,5 @@ cmake = 'cmake'
 [host_machine]
 system = 'linux'
 cpu_family = 'arm'
-cpu = 'generic-armv6+fp'
+cpu = 'generic-armv6zk+vfpv2'
 endian = 'little'

--- a/linux/target-armv6.sh
+++ b/linux/target-armv6.sh
@@ -21,7 +21,12 @@
 
 export ARCH=armv6
 export ARCH_OPENSSL=armv4
-export ARCH_CFLAGS="-mcpu=generic-armv6+fp -mtune=generic-armv6+fp"
+# -march flags from:
+# https://raspberrypi.stackexchange.com/questions/2046/which-cpu-flags-are-suitable-for-gcc-on-raspberry-pi
+# https://stackoverflow.com/questions/35132319/build-for-armv6-with-gnueabihf
+# Disable Thumb since Raspbian doesn't use it and it produces a compiler error:
+# https://thinkingeek.com/2014/12/20/arm-assembler-raspberry-pi-chapter-22/
+export ARCH_CFLAGS="-march=armv6zk+vfpv2 -marm"
 export ARCH_CONFIGURE=arm-linux-gnueabihf
 export CC="$ARCH_CONFIGURE-gcc"
 export ARCH_CMAKE_TOOLCHAIN=toolchain-arm32.cmake


### PR DESCRIPTION
Similar changes as https://github.com/mkxp-z/mkxp-z/pull/214.

Also had to use `-march` instead of `-mcpu` (also inconsistent with GCC docs), and disable Thumb.