### PR TITLE
Enable PIC even for static libraries

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -37,6 +37,7 @@ CMAKE_ARGS := \
 	-DCMAKE_PREFIX_PATH="$(BUILD_PREFIX)" \
 	-DCMAKE_C_FLAGS="$(CFLAGS)" \
 	-DCMAKE_BUILD_TYPE=Release \
+	-DCMAKE_POSITION_INDEPENDENT_CODE=ON \
 	$(ARCH_CMAKE_ARGS)
 
 # TODO: Check if we can disable rubygems, remove prefixes.


### PR DESCRIPTION
Draft because untested, and need to expand to non-CMake and non-Linux builds.

Supersedes https://github.com/mkxp-z/mkxp-z/pull/201 (if it works, anyway).