### PR TITLE
TileAtlasVX: Short-circuit blit scaling

### DIFF
--- a/src/display/gl/gl-meta.h
+++ b/src/display/gl/gl-meta.h
@@ -67,9 +67,9 @@ void vaoUnbind(VAO &vao);
 /* EXT_framebuffer_blit */
 int blitScaleIsSpecial(TEXFBO &target, bool targetPreferHires, const IntRect &targetRect, TEXFBO &source, const IntRect &sourceRect);
 int smoothScalingMethod(int scaleIsSpecial);
-void blitBegin(TEXFBO &target, bool preferHires = false, int scaleIsOne = 0);
-void blitBeginScreen(const Vec2i &size, int scaleIsOne = 0);
-void blitSource(TEXFBO &source, int scaleIsOne = 0);
+void blitBegin(TEXFBO &target, bool preferHires = false, int scaleIsSpecial = 0);
+void blitBeginScreen(const Vec2i &size, int scaleIsSpecial = 0);
+void blitSource(TEXFBO &source, int scaleIsSpecial = 0);
 void blitRectangle(const IntRect &src, const Vec2i &dstPos);
 void blitRectangle(const IntRect &src, const IntRect &dst,
                    bool smooth = false);


### PR DESCRIPTION
Performance improvement is pretty good in extreme scenarios: on LLVMpipe, when replacing xBRZ with Nearest-Neighbor, it decreased the time taken to build the atlas 100 times in a row from 32.0s to 4.6s.