### PR TITLE
Implement serialization for big-endian platforms

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           msystem: mingw64
-          # zip is just used for artifact compression at the end.
           install: >-
             base-devel
             git
@@ -32,13 +31,11 @@ jobs:
             mingw-w64-x86_64-meson
             mingw-w64-x86_64-autotools
             mingw-w64-x86_64-gcc
-            zip
-
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             windows/build-mingw64
@@ -73,16 +70,11 @@ jobs:
           cp ../../mkxp.json .
           cp -r ../../scripts .
           cp ../../assets/LICENSE.mkxp-z-with-https.txt .
-          cd ..
-          # Zipping before uploading decreases the upload time considerably.
-          # Unfortunately this results in double-zipping; tracked at:
-          # https://github.com/actions/upload-artifact/issues/426
-          zip -r artifact.zip artifact
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: mkxp-z.windows.${{github.event_name == 'pull_request' && format('PR{0}', github.event.number) || github.ref_name}}-${{steps.short-sha.outputs.sha}}
-          path: build/artifact.zip
+          path: build/artifact
 
   build-linux-native:
     name: Ubuntu 22.04 x86_64
@@ -94,9 +86,9 @@ jobs:
           length: 7
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             linux/build-x86_64
@@ -129,16 +121,11 @@ jobs:
           cp ../../mkxp.json .
           cp -r ../../scripts .
           cp ../../assets/LICENSE.mkxp-z-with-https.txt .
-          cd ..
-          # Zipping before uploading preserves +x permissions.
-          # Unfortunately this results in double-zipping; tracked at:
-          # https://github.com/actions/upload-artifact/issues/426
-          zip -r local.zip local
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: mkxp-z.linux.x86_64.${{github.event_name == 'pull_request' && format('PR{0}', github.event.number) || github.ref_name}}-${{steps.short-sha.outputs.sha}}
-          path: build/local.zip
+          path: build/local
 
   build-linux-cross:
     name: Ubuntu 22.04 ${{matrix.arch_mkxpz}}
@@ -190,9 +177,9 @@ jobs:
           length: 7
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             linux/build-${{matrix.arch_mkxpz}}
@@ -240,13 +227,11 @@ jobs:
           cp ../../mkxp.json .
           cp -r ../../scripts .
           cp ../../assets/LICENSE.mkxp-z-with-https.txt .
-          cd ..
-          zip -r local.zip local
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: mkxp-z.linux.${{matrix.arch_mkxpz}}.${{github.event_name == 'pull_request' && format('PR{0}', github.event.number) || github.ref_name}}-${{steps.short-sha.outputs.sha}}
-          path: build/local.zip
+          path: build/local
 
   build-macos:
     name: macOS
@@ -261,9 +246,9 @@ jobs:
         run: brew remove --force $(brew list)
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             macos/Dependencies/build-macosx-x86_64
@@ -294,7 +279,7 @@ jobs:
           ditto -c -k --sequesterRsrc --keepParent Z-universal.app Z-universal.app.zip
 
       - name: Upload archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mkxp-z.macos.${{github.event_name == 'pull_request' && format('PR{0}', github.event.number) || github.ref_name}}-${{steps.short-sha.outputs.sha}}
           path: build/Build/Products/Release/Z-universal.app.zip


### PR DESCRIPTION
This pull request implements byte swapping in serial-util.h so that the `Color`, `Rect`, `Table` and `Tone` classes can be serialized and deserialized properly on big-endian architectures like s390x and the big-endian PowerPC processors used by Nintendo GameCube, Wii, Wii U and certain old Apple devices. There don't appear to be any other parts of the codebase that are dependent on endianness. Closes #217.