### PR TITLE
Use upstream Pixman 0.44.0

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -120,7 +120,7 @@ $(DOWNLOADS)/pixman/Makefile: $(DOWNLOADS)/pixman/autogen.sh
 	$(AUTOGEN) --enable-static=yes --enable-shared=no
 
 $(DOWNLOADS)/pixman/autogen.sh:
-	$(CLONE) $(GITHUB)/mkxp-z/pixman $(DOWNLOADS)/pixman
+	$(CLONE) https://gitlab.freedesktop.org/pixman/pixman -b pixman-0.44.0 $(DOWNLOADS)/pixman
 
 
 # iconv

--- a/macos/Dependencies/common.make
+++ b/macos/Dependencies/common.make
@@ -141,7 +141,7 @@ $(DOWNLOADS)/pixman/Makefile: $(DOWNLOADS)/pixman/autogen.sh
 	--disable-arm-a64-neon
 
 $(DOWNLOADS)/pixman/autogen.sh:
-	$(CLONE) $(GITHUB)/mkxp-z/pixman $(DOWNLOADS)/pixman
+	$(CLONE) https://gitlab.freedesktop.org/pixman/pixman -b pixman-0.44.0 $(DOWNLOADS)/pixman
 
 
 # PhysFS

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -115,7 +115,7 @@ $(DOWNLOADS)/pixman/Makefile: $(DOWNLOADS)/pixman/autogen.sh
 	$(AUTOGEN) --enable-static=yes --enable-shared=no
 
 $(DOWNLOADS)/pixman/autogen.sh:
-	$(CLONE) $(GITHUB)/mkxp-z/pixman $(DOWNLOADS)/pixman
+	$(CLONE) https://gitlab.freedesktop.org/pixman/pixman -b pixman-0.44.0 $(DOWNLOADS)/pixman
 
 
 # PhysFS


### PR DESCRIPTION
Fixes ARM builds on Debian Trixie by pulling in the fix for: https://gitlab.freedesktop.org/pixman/pixman/-/issues/96