### PR TITLE
Use `-std=gnu99` when building Ruby

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -327,7 +327,7 @@ $(LIBDIR)/libruby.so.3.1: $(DOWNLOADS)/ruby/Makefile
 $(DOWNLOADS)/ruby/Makefile: $(DOWNLOADS)/ruby/configure
 	cd $(DOWNLOADS)/ruby; \
 	export $(CONFIGURE_ENV); \
-	export CFLAGS="-flto $$CFLAGS"; \
+	export CFLAGS="-std=gnu99 -flto $$CFLAGS"; \
 	export LDFLAGS="-flto $$LDFLAGS"; \
 	./configure $(CONFIGURE_ARGS) $(RUBY_CONFIGURE_ARGS) $(RUBY_FLAGS)
 

--- a/macos/Dependencies/common.make
+++ b/macos/Dependencies/common.make
@@ -310,7 +310,7 @@ $(LIBDIR)/libruby.3.1.dylib: $(DOWNLOADS)/ruby/Makefile
 $(DOWNLOADS)/ruby/Makefile: $(DOWNLOADS)/ruby/configure
 	cd $(DOWNLOADS)/ruby; \
 	export $(CONFIGURE_ENV); \
-	export CFLAGS="-flto=full -DRUBY_FUNCTION_NAME_STRING=__func__ $$CFLAGS"; \
+	export CFLAGS="-std=gnu99 -flto=full -DRUBY_FUNCTION_NAME_STRING=__func__ $$CFLAGS"; \
 	export LDFLAGS="-flto=full $$LDFLAGS"; \
 	./configure $(CONFIGURE_ARGS) $(RUBY_CONFIGURE_ARGS) $(RUBY_FLAGS)
 

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -307,7 +307,7 @@ $(BINDIR)/$(RB_PREFIX)-ruby310.dll: $(DOWNLOADS)/ruby/Makefile
 $(DOWNLOADS)/ruby/Makefile: $(DOWNLOADS)/ruby/configure
 	cd $(DOWNLOADS)/ruby; \
 	export $(CONFIGURE_ENV); \
-	export CFLAGS="-flto $$CFLAGS"; \
+	export CFLAGS="-std=gnu99 -flto $$CFLAGS"; \
 	export LDFLAGS="-flto $$LDFLAGS"; \
 	./configure $(CONFIGURE_ARGS) $(RUBY_CONFIGURE_ARGS) $(RUBY_FLAGS)
 


### PR DESCRIPTION
GCC 15, which is now used by MSYS2, changed the default C standard to C23 with GNU extensions, but the version of Ruby that mkxp-z uses isn't valid C23. Since Ruby is written in C99 with GNU extensions, this should be fixable by passing `-std=gnu99`.

Please note that this won't fix all of the Ruby compilation errors on Windows. There's still at least one remaining problem, which is that MinGW now defines a `clock_gettime()` function, but Ruby assumes it doesn't and tries to define its own version of this function in win32/win32.c, leading to a compilation error. This could be fixed by removing this function from win32/win32.c in mkxp-z's fork of Ruby or by updating Ruby to a version that has proper conditional disabling of the custom `clock_gettime()` implementation.