### PR TITLE
Fix use after free in `SharedMidiState` destructor

### DIFF
--- a/src/audio/sharedmidistate.h
+++ b/src/audio/sharedmidistate.h
@@ -58,13 +58,13 @@ struct SharedMidiState
 		if (!inited || !HAVE_FLUID)
 			return;
 
-		fluid.delete_settings(flSettings);
-
 		for (size_t i = 0; i < synths.size(); ++i)
 		{
 			assert(!synths[i].inUse);
 			fluid.delete_synth(synths[i].synth);
 		}
+
+		fluid.delete_settings(flSettings);
 	}
 
 	void initIfNeeded(const Config &conf)


### PR DESCRIPTION
The new version of FluidSynth used in #264 now requires the `fluid_settings_t` to live for at least as long as all `fluid_synth_t` objects that use it because `delete_fluid_synth()` now accesses the synth's settings object.