### PR TITLE
Fix initial screen dimensions

### DIFF
--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -837,9 +837,9 @@ struct GraphicsPrivate {
     IntruList<Disposable> dispList;
     
     GraphicsPrivate(RGSSThreadData *rtData)
-    : scResLores(DEF_SCREEN_W, DEF_SCREEN_H),
-    scRes(rtData->config.enableHires ? (int)lround(rtData->config.framebufferScalingFactor * DEF_SCREEN_W) : DEF_SCREEN_W,
-        rtData->config.enableHires ? (int)lround(rtData->config.framebufferScalingFactor * DEF_SCREEN_H) : DEF_SCREEN_H),
+    : scResLores(rtData->config.defScreenW, rtData->config.defScreenH),
+    scRes(rtData->config.enableHires ? (int)lround(rtData->config.framebufferScalingFactor * rtData->config.defScreenW) : rtData->config.defScreenW,
+        rtData->config.enableHires ? (int)lround(rtData->config.framebufferScalingFactor * rtData->config.defScreenH) : rtData->config.defScreenH),
     scSize(scRes),
     winSize(rtData->config.defScreenW, rtData->config.defScreenH),
     screen(scRes.x, scRes.y), threadData(rtData),


### PR DESCRIPTION
`graphics.cpp::scRes` used the default `DEF_SCREEN_W` and `DEF_SCREEN_H` instead of `mkxp.json` overrides leading to a rare scenario where certain interactions with game coordinates would be incorrect if you were not using the default 640x480 dimensions, the primary issue being the Mouse.