### PR TITLE
Upgrade libiconv to 1.18

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -126,19 +126,19 @@ $(DOWNLOADS)/pixman/autogen.sh:
 # iconv
 iconv: init_dirs $(LIBDIR)/libiconv.a
 
-$(LIBDIR)/libiconv.a: $(DOWNLOADS)/libiconv-1.16/Makefile
-	cd $(DOWNLOADS)/libiconv-1.16; make; make install
+$(LIBDIR)/libiconv.a: $(DOWNLOADS)/libiconv-1.18/Makefile
+	cd $(DOWNLOADS)/libiconv-1.18; make; make install
 
-$(DOWNLOADS)/libiconv-1.16/Makefile: $(DOWNLOADS)/libiconv-1.16/configure
-	cd $(DOWNLOADS)/libiconv-1.16; \
+$(DOWNLOADS)/libiconv-1.18/Makefile: $(DOWNLOADS)/libiconv-1.18/configure
+	cd $(DOWNLOADS)/libiconv-1.18; \
 	$(CONFIGURE) --enable-static=true --enable-shared=false
 
-$(DOWNLOADS)/libiconv-1.16/configure: $(DOWNLOADS)/libiconv-1.16.tar.gz
+$(DOWNLOADS)/libiconv-1.18/configure: $(DOWNLOADS)/libiconv-1.18.tar.gz
 	cd $(DOWNLOADS); \
-	tar -xzf libiconv-1.16.tar.gz;
+	tar -xzf libiconv-1.18.tar.gz;
 
-$(DOWNLOADS)/libiconv-1.16.tar.gz:
-	wget https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.16.tar.gz -P $(DOWNLOADS)
+$(DOWNLOADS)/libiconv-1.18.tar.gz:
+	wget https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.18.tar.gz -P $(DOWNLOADS)
 
 # uchardet
 uchardet: init_dirs $(LIBDIR)/libuchardet.a


### PR DESCRIPTION
Libiconv 1.16 isn't valid C23, so it won't build with GCC 15, whose default C standard is C23 with GNU extensions. We should upgrade to libiconv 1.18 since the problem was fixed by commit e46dee2f581c1167137bcd045e114e96a9f00483 which is in libiconv 1.18 and later.