### PR TITLE
Use pnggroup/libpng

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -185,7 +185,7 @@ $(DOWNLOADS)/libpng/Makefile: $(DOWNLOADS)/libpng/configure
 	--enable-shared=no --enable-static=yes
 
 $(DOWNLOADS)/libpng/configure:
-	$(CLONE) $(GITHUB)/pnggroup/libpng -b v1.6.37 $(DOWNLOADS)/libpng
+	$(CLONE) $(GITHUB)/pnggroup/libpng -b v1.6.50 $(DOWNLOADS)/libpng
 
 # SDL2
 sdl2: init_dirs $(LIBDIR)/libSDL2.a

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -185,7 +185,7 @@ $(DOWNLOADS)/libpng/Makefile: $(DOWNLOADS)/libpng/configure
 	--enable-shared=no --enable-static=yes
 
 $(DOWNLOADS)/libpng/configure:
-	$(CLONE) $(GITHUB)/mkxp-z/libpng $(DOWNLOADS)/libpng
+	$(CLONE) $(GITHUB)/pnggroup/libpng -b v1.6.37 $(DOWNLOADS)/libpng
 
 # SDL2
 sdl2: init_dirs $(LIBDIR)/libSDL2.a

--- a/macos/Dependencies/common.make
+++ b/macos/Dependencies/common.make
@@ -173,7 +173,7 @@ $(DOWNLOADS)/libpng/Makefile: $(DOWNLOADS)/libpng/configure
 	--enable-shared=no --enable-static=yes
 
 $(DOWNLOADS)/libpng/configure:
-	$(CLONE) $(GITHUB)/pnggroup/libpng -b v1.6.37 $(DOWNLOADS)/libpng
+	$(CLONE) $(GITHUB)/pnggroup/libpng -b v1.6.50 $(DOWNLOADS)/libpng
 
 # SDL2
 sdl2: init_dirs $(LIBDIR)/libSDL2.a

--- a/macos/Dependencies/common.make
+++ b/macos/Dependencies/common.make
@@ -173,7 +173,7 @@ $(DOWNLOADS)/libpng/Makefile: $(DOWNLOADS)/libpng/configure
 	--enable-shared=no --enable-static=yes
 
 $(DOWNLOADS)/libpng/configure:
-	$(CLONE) $(GITHUB)/mkxp-z/libpng $(DOWNLOADS)/libpng
+	$(CLONE) $(GITHUB)/pnggroup/libpng -b v1.6.37 $(DOWNLOADS)/libpng
 
 # SDL2
 sdl2: init_dirs $(LIBDIR)/libSDL2.a

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -147,7 +147,7 @@ $(DOWNLOADS)/libpng/Makefile: $(DOWNLOADS)/libpng/configure
 	--enable-shared=no --enable-static=yes
 
 $(DOWNLOADS)/libpng/configure:
-	$(CLONE) $(GITHUB)/pnggroup/libpng -b v1.6.37 $(DOWNLOADS)/libpng
+	$(CLONE) $(GITHUB)/pnggroup/libpng -b v1.6.50 $(DOWNLOADS)/libpng
 
 # uchardet
 uchardet: init_dirs $(LIBDIR)/libuchardet.a

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -147,7 +147,7 @@ $(DOWNLOADS)/libpng/Makefile: $(DOWNLOADS)/libpng/configure
 	--enable-shared=no --enable-static=yes
 
 $(DOWNLOADS)/libpng/configure:
-	$(CLONE) $(GITHUB)/mkxp-z/libpng $(DOWNLOADS)/libpng
+	$(CLONE) $(GITHUB)/pnggroup/libpng -b v1.6.37 $(DOWNLOADS)/libpng
 
 # uchardet
 uchardet: init_dirs $(LIBDIR)/libuchardet.a


### PR DESCRIPTION
I attempted to build mkxp-z on GitHub's new `macos-26` runner and the build failed while compiling `libpng`. 

After some Discord discussion we realized that mkxp-z is using a forked libpng. Using newer official libpng fixes the issue.

---

<img width="831" height="197" alt="image" src="https://github.com/user-attachments/assets/9b4d4b72-8cb4-48b9-bc20-8fb78fddb639" />