### PR TITLE
CI: Add `libgomp-1.dll` to Windows binaries

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -62,6 +62,7 @@ jobs:
         run: |
           mkdir build/artifact
           cd build/artifact
+          cp /mingw64/bin/libgomp-1.dll .
           cp /mingw64/bin/zlib1.dll .
           cp ../../windows/build-mingw64/bin/x64-msvcrt-ruby310.dll .
           cp -r ../../windows/build-mingw64/lib/ruby/3.1.0 .


### PR DESCRIPTION
Fixes https://github.com/mkxp-z/mkxp-z/issues/266