### PR TITLE
Soft reset on controller's guide button

### DIFF
--- a/src/eventthread.cpp
+++ b/src/eventthread.cpp
@@ -425,10 +425,34 @@ void EventThread::process(RGSSThreadData &rtData)
                 break;
                 
             case SDL_CONTROLLERBUTTONDOWN:
+                if (event.cbutton.button == SDL_CONTROLLER_BUTTON_GUIDE)
+                {
+                    if (!rtData.config.enableReset)
+                        break;
+
+                    if (resetting)
+                        break;
+
+                    resetting = true;
+                    rtData.rqResetFinish.clear();
+                    rtData.rqReset.set();
+                    break;
+                }
+
                 controllerState.buttons[event.cbutton.button] = true;
                 break;
                 
             case SDL_CONTROLLERBUTTONUP:
+                if (event.cbutton.button == SDL_CONTROLLER_BUTTON_GUIDE)
+                {
+                    if (!rtData.config.enableReset)
+                        break;
+
+                    resetting = false;
+                    rtData.rqResetFinish.set();
+                    break;
+                }
+
                 controllerState.buttons[event.cbutton.button] = false;
                 break;
                 

--- a/src/settingsmenu.cpp
+++ b/src/settingsmenu.cpp
@@ -1105,6 +1105,13 @@ bool SettingsMenu::onEvent(const SDL_Event &event)
 		}
 
 	case SDL_CONTROLLERBUTTONDOWN:
+        /* Don't let the user bind keys that trigger
+         * mkxp functions */
+        if (event.cbutton.button == SDL_CONTROLLER_BUTTON_GUIDE) {
+            return true;
+        }
+        // intentionally no break
+
 	case SDL_CONTROLLERAXISMOTION:
 		if (p->state != AwaitingInput)
 			return true;


### PR DESCRIPTION
Made this change a long time ago in my fork. The issue was that F12 reset was only available for keyboard player but not for controller player. Is this something you'd like to have in base mkxp-z or should I keep it as a fork feature?