### PR TITLE
Configurable input repeat

### DIFF
--- a/mkxp.json
+++ b/mkxp.json
@@ -530,10 +530,16 @@
     //  "x": ...,
     // },
 
-
     // Dump tile atlas (for debugging purposes)
     // (default: false)
     //
     // "dumpAtlas": false,
 
+    // Changes the initial delay for input repeat when a button
+    // is held (approximate time in seconds).
+    // "inputRepeatStart": 0.4,
+
+    // Changes how often an input repeat is triggered when a button
+    // is held (approximate time in seconds).
+    // "inputRepeatDelay": 0.1,
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -198,6 +198,8 @@ void Config::read(int argc, char *argv[]) {
         {"JITMinCalls", 10000},
         {"YJITEnable", false},
         {"dumpAtlas", false},
+        {"inputRepeatStart", 0.4},
+        {"inputRepeatDelay", 0.1},
         {"bindingNames", json::object({
             {"a", "A"},
             {"b", "B"},
@@ -315,7 +317,9 @@ try { exp } catch (...) {}
     SET_STRINGOPT(customScript, customScript);
     SET_OPT(useScriptNames, boolean);
     SET_OPT(dumpAtlas, boolean);
-    
+    SET_OPT(inputRepeatStart, number);
+    SET_OPT(inputRepeatDelay, number);
+
     fillStringVec(opts["preloadScript"], preloadScripts);
     fillStringVec(opts["postloadScript"], postloadScripts);
     fillStringVec(opts["RTP"], rtps);

--- a/src/config.h
+++ b/src/config.h
@@ -92,7 +92,10 @@ struct Config {
     std::string iconPath;
     std::string execName;
     std::string titleLanguage;
-    
+
+    double inputRepeatStart;
+    double inputRepeatDelay;
+
     struct {
         std::string soundFont;
         bool chorus;

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -727,7 +727,7 @@ struct InputPrivate
         int active;
     } dir8Data;
     
-    void recalcRepeatTime(unsigned int fps) {
+    void recalcRepeatTime(unsigned int fps, double start, double delay) {
         // 0 fps would cause a divide by zero segfault later.
         // Bail in that case.
         if (fps == 0)
@@ -736,11 +736,7 @@ struct InputPrivate
         }
 
         double framems = 1.f / fps;
-        
-        // Approximate time in milliseconds
-        double start = (rgssVer >= 2) ? 0.375 : 0.400;
-        double delay = 0.100;
-        
+
         repeatStart = ceil(start / framems);
         repeatDelay = ceil(delay / framems);
     }
@@ -757,7 +753,7 @@ struct InputPrivate
         
         int fps = rtData.config.fixedFramerate;
         if (!fps) fps = (rgssVer >= 2) ? 60 : 40;
-        recalcRepeatTime(fps);
+        recalcRepeatTime(fps, rtData.config.inputRepeatStart, rtData.config.inputRepeatDelay);
         
         states    = stateArray;
         statesOld = stateArray + BUTTON_CODE_COUNT;
@@ -1195,7 +1191,7 @@ double Input::getDelta() {
 }
 
 void Input::recalcRepeat(unsigned int fps) {
-    p->recalcRepeatTime(fps);
+    p->recalcRepeatTime(fps, shState->config().inputRepeatStart, shState->config().inputRepeatDelay);
 }
 
 void Input::update()


### PR DESCRIPTION
Another small thing that can possibly be backported. A pain point for our players was the fact that scrolling through a long list was taking a long time due to how infrequently input repeat occurs. So initially we just had a custom value in our code and later on we made it configurable (with some help from mkxp-z Discord community).