### PR TITLE
Fix average FPS not being updated when integer scaling is active without last mile scaling

### DIFF
--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -1058,6 +1058,7 @@ struct GraphicsPrivate {
             GLMeta::blitEnd();
             
             swapGLBuffer();
+            updateAvgFPS();
             return;
         }
         


### PR DESCRIPTION
* Closes #232 
* Closes #298 