### PR TITLE
Run scripts in the context of nil when RGSS version is 1

### DIFF
--- a/binding/binding-mri.cpp
+++ b/binding/binding-mri.cpp
@@ -1252,7 +1252,7 @@ static void mriBindingExecute() {
 #endif
 #endif
     
-    topSelf = rb_eval_string("self");
+    topSelf = rgssVer == 1 ? Qnil : rb_eval_string("self");
     
     VALUE rbArgv = rb_get_argv();
     for (const auto &str : conf.launchArgs)


### PR DESCRIPTION
See https://github.com/mkxp-z/mkxp-z/issues/291#issuecomment-3651003987. The behaviour from before #295 is correct for RPG Maker XP, and the changes from #295 should only be used for RPG Maker VX and RPG Maker VX Ace.