### PR TITLE
Enable IME support

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -194,13 +194,27 @@ $(LIBDIR)/libSDL2.a: $(DOWNLOADS)/sdl2/cmakebuild/Makefile
 	cd $(DOWNLOADS)/sdl2/cmakebuild; \
 	make -j$(NPROC); make install
 
-$(DOWNLOADS)/sdl2/cmakebuild/Makefile: $(DOWNLOADS)/sdl2/CMakeLists.txt
+$(DOWNLOADS)/sdl2/cmakebuild/Makefile: $(DOWNLOADS)/sdl2/CMakeLists.txt $(LIBDIR)/libdbus-1.so.3.38.3
 	cd $(DOWNLOADS)/sdl2; \
 	mkdir cmakebuild; cd cmakebuild; \
-	$(CMAKE) -DBUILD_SHARED_LIBS=no
+	$(CMAKE) -DBUILD_SHARED_LIBS=no -DSDL_DBUS=yes
 
 $(DOWNLOADS)/sdl2/CMakeLists.txt:
 	$(CLONE) $(GITHUB)/mkxp-z/SDL $(DOWNLOADS)/sdl2 -b mkxp-z-2.28.1
+
+# dbus
+
+$(LIBDIR)/libdbus-1.so.3.38.3: $(DOWNLOADS)/dbus/cmakebuild/Makefile
+	cd $(DOWNLOADS)/dbus/cmakebuild; \
+	make -j$(NPROC); make install
+
+$(DOWNLOADS)/dbus/cmakebuild/Makefile: $(DOWNLOADS)/dbus/CMakeLists.txt
+	cd $(DOWNLOADS)/dbus; \
+	mkdir cmakebuild; cd cmakebuild; \
+	$(CMAKE) -DDBUS_WITH_GLIB=no
+
+$(DOWNLOADS)/dbus/CMakeLists.txt: init_dirs
+	$(CLONE) https://gitlab.freedesktop.org/dbus/dbus $(DOWNLOADS)/dbus -b dbus-1.16.2
 
 # SDL_image
 sdl2image: init_dirs sdl2 $(LIBDIR)/libSDL2_image.a

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -211,7 +211,7 @@ $(LIBDIR)/libdbus-1.so.3.38.3: $(DOWNLOADS)/dbus/cmakebuild/Makefile
 $(DOWNLOADS)/dbus/cmakebuild/Makefile: $(DOWNLOADS)/dbus/CMakeLists.txt
 	cd $(DOWNLOADS)/dbus; \
 	mkdir cmakebuild; cd cmakebuild; \
-	$(CMAKE) -DDBUS_WITH_GLIB=no
+	$(CMAKE) -DDBUS_WITH_GLIB=no -DDBUS_SESSION_SOCKET_DIR=/tmp
 
 $(DOWNLOADS)/dbus/CMakeLists.txt: init_dirs
 	$(CLONE) https://gitlab.freedesktop.org/dbus/dbus $(DOWNLOADS)/dbus -b dbus-1.16.2

--- a/src/eventthread.cpp
+++ b/src/eventthread.cpp
@@ -517,6 +517,10 @@ void EventThread::process(RGSSThreadData &rtData)
                     case REQUEST_TEXTMODE :
                         if (event.user.code)
                         {
+                            {
+                                const SDL_Rect rect = {0, 0, 1, 1};
+                                SDL_SetTextInputRect(&rect);
+                            }
                             SDL_StartTextInput();
                             lockText(true);
                             textInputBuffer.clear();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -209,6 +209,8 @@ int main(int argc, char *argv[]) {
     SDL_SetHint(SDL_HINT_OPENGL_ES_DRIVER, "1");
 #endif
 
+    SDL_SetHint(SDL_HINT_IME_SHOW_UI, "1");
+
     /* initialize SDL first */
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER | SDL_INIT_TIMER) < 0) {
       showInitError(std::string("Error initializing SDL: ") + SDL_GetError());


### PR DESCRIPTION
On Linux, either D-Bus (for Fcitx/Fcitx5-compatible IMEs) or IBus (for IBus-compatible IMEs) support in SDL needs to be enabled for IMEs to work, so I've enabled D-Bus support. I have no idea how to compile IBus.

On Windows, the hint `SDL_HINT_IME_SHOW_UI` needs to be set for the IME window to appear.

Users can use IMEs while `Input.text_input` is set to `true` by the currently running game.

* Closes #303 