### PR TITLE
Recognize SFNT family names for fonts

### DIFF
--- a/src/display/font.cpp
+++ b/src/display/font.cpp
@@ -239,7 +239,7 @@ void SharedFontState::initFontSetCB(SDL_RWops &ops,
 		for (unsigned int i = 0, name_count = FT_Get_Sfnt_Name_Count(face); i < name_count; ++i)
 		{
 			FT_SfntName aname;
-			if (FT_Get_Sfnt_Name(face, i, &aname) || aname.string_len == 0)
+			if (FT_Get_Sfnt_Name(face, i, &aname))
 				continue;
 			uint32_t key = aname.platform_id;
 			key <<= 16;
@@ -259,7 +259,7 @@ void SharedFontState::initFontSetCB(SDL_RWops &ops,
 		{
 			const std::string &sfnt_family_raw = entry.second.first;
 			const std::string &sfnt_style = entry.second.second;
-			if (sfnt_family_raw.empty() || sfnt_style.empty())
+			if (sfnt_family_raw.empty())
 				continue;
 
 			std::string sfnt_family(sfnt_family_raw);

--- a/src/util/encoding.h
+++ b/src/util/encoding.h
@@ -31,16 +31,13 @@ static std::string getCharset(std::string &str) {
     return ret;
 }
 
-static std::string convertString(std::string &str) {
-    
-    std::string charset = getCharset(str);
-    
+static std::string convertString(std::string &str, const char *charset) {
     // Conversion doesn't need to happen if it's already UTF-8
-    if (!strcmp(charset.c_str(), "UTF-8") || !strcmp(charset.c_str(), "ASCII")) {
+    if (!strcmp(charset, "UTF-8") || !strcmp(charset, "ASCII")) {
         return std::string(str);
     }
     
-    iconv_t cd = iconv_open("UTF-8", charset.c_str());
+    iconv_t cd = iconv_open("UTF-8", charset);
     
     size_t inLen = str.size();
     size_t outLen = inLen * 4;
@@ -58,10 +55,14 @@ static std::string convertString(std::string &str) {
         buf.resize(buf.size()-outLen);
     }
     else {
-        throw Exception(Exception::MKXPError, "Unable to convert string (Guessed encoding: %s)", charset.c_str());
+        throw Exception(Exception::MKXPError, "Unable to convert string (Guessed encoding: %s)", charset);
     }
     
     return buf;
+}
+
+static std::string convertString(std::string &str) {
+    return convertString(str, getCharset(str).c_str());
 }
 }
 


### PR DESCRIPTION
The font family names that the stock RPG Maker runtimes recognize for fonts differ from the ones that FreeType returns sometimes. The SFNT font family names seem to be more accurate to the ones that the stock runtimes recognize (for example, for the font mentioned in #307, the normal FreeType family name is "Noto Sans CJK TC" but the SFNT family name is "Noto Sans CJK TC Black"), so I've made modifications to font.cpp so that SFNT font family names are recognized in addition to the font family names returned by FreeType normally.

If there are two different font files where one file's SFNT family name is the same as the normal FreeType family name of the other file, the SFNT family name takes precedence over the normal FreeType family name, so the font file whose SFNT family name matches will be used instead of the other one.

* Closes #307 