### PR TITLE
Table: Better handle out of bounds write attempts

### DIFF
--- a/binding/table-binding.cpp
+++ b/binding/table-binding.cpp
@@ -120,7 +120,7 @@ RB_METHOD_GUARD_END
 RB_METHOD_GUARD(tableSetAt) {
   Table *t = getPrivateData<Table>(self);
 
-  int x, y, z, value;
+  int x, y, z;
   x = y = z = 0;
 
   if (argc < 2)
@@ -130,27 +130,30 @@ RB_METHOD_GUARD(tableSetAt) {
   default:
   case 2:
     x = NUM2INT(argv[0]);
-    value = NUM2INT(argv[1]);
 
     break;
   case 3:
     x = NUM2INT(argv[0]);
     y = NUM2INT(argv[1]);
-    value = NUM2INT(argv[2]);
 
     break;
   case 4:
     x = NUM2INT(argv[0]);
     y = NUM2INT(argv[1]);
     z = NUM2INT(argv[2]);
-    value = NUM2INT(argv[3]);
 
     break;
   }
 
-  t->set(value, x, y, z);
+  /* OOB writes are silently ignored */
+  VALUE rbValue = argv[argc - 1];
+  if (!t->indexValid(x, y, z))
+    return rbValue;
 
-  return argv[argc - 1];
+  /* Only tranform the value when indices are in bounds */
+  t->set(NUM2INT(rbValue), x, y, z);
+
+  return rbValue;
 }
 RB_METHOD_GUARD_END
 

--- a/src/etc/table.cpp
+++ b/src/etc/table.cpp
@@ -46,13 +46,6 @@ int16_t Table::get(int x, int y, int z) const
 
 void Table::set(int16_t value, int x, int y, int z)
 {
-	if (x < 0 || x >= xs
-	||  y < 0 || y >= ys
-	||  z < 0 || z >= zs)
-	{
-		return;
-	}
-
 	data[xs*ys*z + xs*y + x] = value;
 
 	modified();

--- a/src/etc/table.h
+++ b/src/etc/table.h
@@ -41,6 +41,7 @@ public:
 	int zSize() const { return zs; }
 
 	int16_t get(int x, int y = 0, int z = 0) const;
+	/* Index must be bounds checked beforehand */
 	void set(int16_t value, int x, int y = 0, int z = 0);
 
 	void resize(int x, int y, int z);
@@ -60,6 +61,11 @@ public:
 	inline const int16_t &at(int x, int y = 0, int z = 0) const
 	{
 		return data[xs*ys*z + xs*y + x];
+	}
+
+	inline bool indexValid(int x, int y = 0, int z = 0) const
+	{
+		return x >= 0 && x < xs && y >= 0 && y < ys && z >= 0 && z <= zs;
 	}
 
     sigslot::signal<> modified;


### PR DESCRIPTION
Writing OOB should silently be ignored for all value types, not just integer-like values.
This matches RMXP/VXA behavior.

Untested because I wasn't able to run my local build due to zlib issues; will test with automated build.