### PR TITLE
Remove spaces before argument parentheses in Ruby 1.8 scripts

### DIFF
--- a/binding/binding-mri.cpp
+++ b/binding/binding-mri.cpp
@@ -48,6 +48,7 @@ extern "C" {
 
 #if RAPI_FULL >= 190
 #include <ruby/encoding.h>
+#include <ruby/re.h>
 #endif
 }
 
@@ -149,6 +150,11 @@ RB_METHOD(mriRgssMain);
 RB_METHOD(mriRgssStop);
 RB_METHOD(_kernelCaller);
 
+#if RAPI_FULL >= 190
+RB_METHOD(kernelEval18);
+RB_METHOD(basicObjectInstanceEval18);
+#endif // RAPI_FULL >= 190
+
 RB_METHOD(mkxpStringToUTF8);
 RB_METHOD(mkxpStringToUTF8Bang);
 
@@ -206,6 +212,15 @@ static void mriBindingInit() {
                         "caller");
         _rb_define_module_function(rb_mKernel, "caller", _kernelCaller);
     }
+
+#if RAPI_FULL >= 190
+    if (shState->rtData().config.syntaxTransformCustomVersionMajor < 1 || (shState->rtData().config.syntaxTransformCustomVersionMajor == 1 && shState->rtData().config.syntaxTransformCustomVersionMajor <= 8)) {
+        rb_define_alias(rb_singleton_class(rb_mKernel), "_mkxp_kernel_eval_alias", "eval");
+        _rb_define_module_function(rb_mKernel, "eval", kernelEval18);
+        rb_define_alias(rb_cBasicObject, "_mkxp_basic_object_instance_eval_alias", "instance_eval");
+        _rb_define_method(rb_cBasicObject, "instance_eval", basicObjectInstanceEval18);
+    }
+#endif // RAPI_FULL >= 190
     
     if (rgssVer == 1)
         rb_eval_string(module_rpg1);
@@ -926,6 +941,86 @@ RB_METHOD(_kernelCaller) {
     
     return trace;
 }
+
+#if RAPI_FULL >= 190
+struct KernelEvalArgs {
+    int argc;
+    VALUE *argv;
+    VALUE result;
+    VALUE exception;
+};
+
+static VALUE kernelEval18Func(KernelEvalArgs *args) {
+    args->result = rb_funcall2(rb_mKernel, rb_intern("_mkxp_kernel_eval_alias"), args->argc, args->argv);
+    return Qnil;
+}
+
+static VALUE kernelEval18Rescue(KernelEvalArgs *args, VALUE exception) {
+    args->exception = exception;
+    return Qnil;
+}
+
+static void kernelEval18Sub(int argc, VALUE *argv) {
+    if (argc >= 1 && RB_TYPE_P(argv[0], T_STRING)) {
+        /* Remove whitespace from between the method name and the opening parenthesis in method calls to before the method name; e.g. "f (1, 2)" -> "f(1, 2)" */
+        argv[0] = rb_funcall(argv[0], rb_intern("gsub"), 2, rb_reg_regcomp(rb_utf8_str_new_cstr("\\b([A-Za-z_]\\w*)\\s+\\(")), rb_utf8_str_new_cstr("\\1("));
+    }
+}
+
+RB_METHOD(kernelEval18) {
+    RB_UNUSED_PARAM;
+
+    KernelEvalArgs args {argc, argv, Qundef, Qundef};
+#if RAPI_FULL < 270
+    rb_rescue2((VALUE(*)(ANYARGS))kernelEval18Func, (VALUE)&args, (VALUE(*)(ANYARGS))kernelEval18Rescue, (VALUE)&args, rb_eSyntaxError, (VALUE)0);
+#else
+    rb_rescue2((VALUE(*)(VALUE))kernelEval18Func, (VALUE)&args, (VALUE(*)(VALUE, VALUE))kernelEval18Rescue, (VALUE)&args, rb_eSyntaxError, (VALUE)0);
+#endif
+
+    if (args.exception != Qundef) {
+        kernelEval18Sub(argc, argv);
+        args.result = rb_funcall2(rb_mKernel, rb_intern("_mkxp_kernel_eval_alias"), argc, argv);
+    }
+
+    return args.result;
+}
+
+struct BasicObjectInstanceEvalArgs {
+    int argc;
+    VALUE *argv;
+    VALUE self;
+    VALUE result;
+    VALUE exception;
+};
+
+static VALUE basicObjectInstanceEval18Func(BasicObjectInstanceEvalArgs *args) {
+    args->result = rb_funcall2(args->self, rb_intern("_mkxp_basic_object_instance_eval_alias"), args->argc, args->argv);
+    return Qnil;
+}
+
+static VALUE basicObjectInstanceEval18Rescue(BasicObjectInstanceEvalArgs *args, VALUE exception) {
+    args->exception = exception;
+    return Qnil;
+}
+
+RB_METHOD(basicObjectInstanceEval18) {
+    RB_UNUSED_PARAM;
+
+    BasicObjectInstanceEvalArgs args {argc, argv, self, Qundef, Qundef};
+#if RAPI_FULL < 270
+    rb_rescue2((VALUE(*)(ANYARGS))basicObjectInstanceEval18Func, (VALUE)&args, (VALUE(*)(ANYARGS))basicObjectInstanceEval18Rescue, (VALUE)&args, rb_eSyntaxError, (VALUE)0);
+#else
+    rb_rescue2((VALUE(*)(VALUE))basicObjectInstanceEval18Func, (VALUE)&args, (VALUE(*)(VALUE, VALUE))basicObjectInstanceEval18Rescue, (VALUE)&args, rb_eSyntaxError, (VALUE)0);
+#endif
+
+    if (args.exception != Qundef) {
+        kernelEval18Sub(argc, argv);
+        args.result = rb_funcall2(self, rb_intern("_mkxp_basic_object_instance_eval_alias"), argc, argv);
+    }
+
+    return args.result;
+}
+#endif // RAPI_FULL >= 190
 
 VALUE kernelLoadDataInt(const char *filename, bool rubyExc, bool raw);
 

--- a/mkxp.json
+++ b/mkxp.json
@@ -32,6 +32,31 @@
     //       the built-in framerate display.
 
 
+    // Apply a syntax transform to help games that require old Ruby syntax run
+    // in modern Ruby. If this is enabled, the syntax transform is only applied
+    // to the game scripts in Scripts.rxdata, Scripts.rvdata or Scripts.rvdata2.
+    // Any `eval` or `instance_eval` calls made from code with syntax transform
+    // enabled also enable syntax transform for the evaluated code. The syntax
+    // transform is not applied to any other Ruby scripts, such as preload
+    // scripts, postload scripts, the `customScript` specified in mkxp.json, the
+    // Ruby standard library, or scripts imported using `require` or
+    // `require_relative`.
+    // 0: Disabled (use modern Ruby syntax for all Ruby scripts)
+    // 1: Custom (use the Ruby version specified by `syntaxTransformCustomVersionMajor`, `syntaxTransformCustomVersionMinor` and `syntaxTransformCustomVersionTeeny`)
+    // 2: Compatibility mode (equivalent to Ruby 1.9.2 if the RGSS version is 3, or Ruby 1.8.1 otherwise)
+    // (default: 0 if mkxp.json exists, 2 if mkxp.json does not exist)
+    //
+    // "syntaxTransform": 0,
+
+
+    // When syntax transform is set to 1, these settings control the targeted
+    // Ruby version.
+    //
+    // "syntaxTransformCustomVersionMajor": 1,
+    // "syntaxTransformCustomVersionMinor": 0,
+    // "syntaxTransformCustomVersionTeeny": 0,
+
+
     // Specify the RGSS version to run under.
     // Possible values are 0, 1, 2, 3. If set to 0,
     // mkxp will try to guess the required version

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -97,11 +97,11 @@ bool getEnvironmentBool(const char *env, bool defaultValue) {
     return defaultValue;
 }
 
-json::value readConfFile(const char *path) {
+json::value readConfFile(const char *path, bool isBaseConf) {
     
     json::value ret(0);
     if (!mkxp_fs::fileExists(path)) {
-        return json::object({});
+        return isBaseConf ? json::object({{"syntaxTransform", 2}}) : json::object({});
     }
     
     try {
@@ -127,6 +127,10 @@ Config::Config() {}
 
 void Config::read(int argc, char *argv[]) {
     auto optsJ = json::object({
+        {"syntaxTransform", 0},
+        {"syntaxTransformCustomVersionMajor", 1},
+        {"syntaxTransformCustomVersionMinor", 0},
+        {"syntaxTransformCustomVersionTeeny", 0},
         {"rgssVersion", 0},
         {"debugMode", false},
         {"displayFPS", false},
@@ -235,7 +239,7 @@ try { exp } catch (...) {}
         }
     }
     
-    json::value baseConf = readConfFile(CONF_FILE);
+    json::value baseConf = readConfFile(CONF_FILE, true);
     copyObject(optsJ, baseConf);
     copyObject(opts["bindingNames"], baseConf.as_object()["bindingNames"], "bindingNames .");
     
@@ -255,6 +259,10 @@ try { exp } catch (...) {}
     SET_OPT_CUSTOMKEY(jit.maxCache, JITMaxCache, integer);
     SET_OPT_CUSTOMKEY(jit.minCalls, JITMinCalls, integer);
     SET_OPT_CUSTOMKEY(yjit.enabled, YJITEnable, boolean);
+    SET_OPT(syntaxTransform, integer);
+    SET_OPT(syntaxTransformCustomVersionMajor, integer);
+    SET_OPT(syntaxTransformCustomVersionMinor, integer);
+    SET_OPT(syntaxTransformCustomVersionTeeny, integer);
     SET_OPT(rgssVersion, integer);
     SET_OPT(defScreenW, integer);
     SET_OPT(defScreenH, integer);
@@ -268,7 +276,7 @@ try { exp } catch (...) {}
     
     // Now check for an extra mkxp.conf in the user's save directory and merge anything else from that
     userConfPath = mkxp_fs::normalizePath(std::string(customDataPath + "/" CONF_FILE).c_str(), 0, 1);
-    json::value userConf = readConfFile(userConfPath.c_str());
+    json::value userConf = readConfFile(userConfPath.c_str(), false);
     copyObject(optsJ, userConf);
     
     // now RESUME

--- a/src/config.h
+++ b/src/config.h
@@ -32,6 +32,10 @@ struct Config {
     // Used for sending the JSON data to Ruby as System::CONFIG
     json5pp::value raw;
     
+    int syntaxTransform;
+    int syntaxTransformCustomVersionMajor;
+    int syntaxTransformCustomVersionMinor;
+    int syntaxTransformCustomVersionTeeny;
     int rgssVersion;
     
     bool debugMode;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,7 @@
 #include <string>
 #include <unistd.h>
 #include <regex>
+#include <climits>
 
 #include "binding.h"
 #include "sharedstate.h"
@@ -170,6 +171,33 @@ static void printRgssVersion(int ver) {
   Debug() << buf;
 }
 
+static void initSyntaxTransform(Config &conf) {
+  char buf[128];
+
+  switch (conf.syntaxTransform) {
+    default:
+      conf.syntaxTransformCustomVersionMajor = INT_MAX;
+      conf.syntaxTransformCustomVersionMinor = INT_MAX;
+      conf.syntaxTransformCustomVersionTeeny = INT_MAX;
+      snprintf(buf, sizeof(buf), "Disabled");
+      break;
+    case 1:
+      conf.syntaxTransformCustomVersionMajor = std::max(0, conf.syntaxTransformCustomVersionMajor);
+      conf.syntaxTransformCustomVersionMinor = std::max(0, conf.syntaxTransformCustomVersionMinor);
+      conf.syntaxTransformCustomVersionTeeny = std::max(0, conf.syntaxTransformCustomVersionTeeny);
+      snprintf(buf, sizeof(buf), "Ruby %u.%u.%u", conf.syntaxTransformCustomVersionMajor, conf.syntaxTransformCustomVersionMinor, conf.syntaxTransformCustomVersionTeeny);
+      break;
+    case 2:
+      conf.syntaxTransformCustomVersionMajor = 1;
+      conf.syntaxTransformCustomVersionMinor = conf.rgssVersion >= 3 ? 9 : 8;
+      conf.syntaxTransformCustomVersionTeeny = conf.rgssVersion >= 3 ? 2 : 1;
+      snprintf(buf, sizeof(buf), "Compatibility mode (Ruby %u.%u.%u)", conf.syntaxTransformCustomVersionMajor, conf.syntaxTransformCustomVersionMinor, conf.syntaxTransformCustomVersionTeeny);
+      break;
+  }
+
+  Debug() << "Syntax transform:" << buf;
+}
+
 static void rgssThreadError(RGSSThreadData *rtData, const std::string &msg) {
   rtData->rgssErrorMsg = msg;
   rtData->ethread->requestTerminate();
@@ -269,6 +297,8 @@ int main(int argc, char *argv[]) {
 
     assert(conf.rgssVersion >= 1 && conf.rgssVersion <= 3);
     printRgssVersion(conf.rgssVersion);
+
+    initSyntaxTransform(conf);
 
     int imgFlags = IMG_INIT_PNG | IMG_INIT_JPG;
     if (IMG_Init(imgFlags) != imgFlags) {


### PR DESCRIPTION
This is an alternative to #304 that doesn't require patching Ruby but only fixes the space before argument parentheses problem.

It does this using a regular expression, which is slightly less reliable than the approach in #304 but works for most games without creating syntax errors in the Ruby standard library like #304 does (#304 resolves this problem by only enabling the syntax transform in the game scripts, which again requires patching Ruby so we can't do that here).

It uses the same `syntaxTransform` config option in mkxp.json that #304 uses.

I've verified that this allows Visions & Voices from https://www.rpgmakerweb.com/downloads to run as well as Memories of Mana (#209). It does not, however, allow Star Stealing Prince to run like #304 does because that game has at least two other distinct types of syntax error that this transformation alone doesn't fix.

* Closes #209 