### PR TITLE
Fixed mousewheel input not counting while holding another key

### DIFF
--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -1225,6 +1225,8 @@ void Input::update()
     p->mousePos[1] = shState->eThread().mouseState.y;
     p->mouseInWindow = shState->eThread().mouseState.inWindow;
     
+    /* Fetch new cumulative scroll distance and reset counter */
+    p->vScrollDistance = SDL_AtomicSet(&EventThread::verticalScrollDistance, 0);
     
     /* Check for new repeating key */
     if (repeatCand != None && repeatCand != p->repeating)
@@ -1258,9 +1260,6 @@ void Input::update()
     }
     
     p->repeating = None;
-    
-    /* Fetch new cumulative scroll distance and reset counter */
-    p->vScrollDistance = SDL_AtomicSet(&EventThread::verticalScrollDistance, 0);
     
     p->last_update = shState->runTime();
 }


### PR DESCRIPTION
This is a fix by @PieGodEx that allows the value of `Input.scroll_v` to update while an input button is being held down.