### PR TITLE
Change the default value of `fontHeightReporting` to 1

### DIFF
--- a/mkxp.json
+++ b/mkxp.json
@@ -455,8 +455,8 @@
     // Controls the algorithm for reporting the height of rendered text.
     // 0: Nominal (TTF_FontHeight); matches RGSS behavior; may cut off bottoms of some characters.
     // 1: Rendered (TTF_SizeUTF8); deviates from RGSS; may look better.
-    // (default: 0)
-    // "fontHeightReporting": 0,
+    // (default: 1)
+    // "fontHeightReporting": 1,
 
     // Crops top row and left column of text that has an outline.
     // Disabling it generally looks nicer, but RGSS enables it, so enabling it

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -194,7 +194,7 @@ void Config::read(int argc, char *argv[]) {
         {"fontScale", 0.0f},
         {"fontKerning", true},
         {"fontHinting", 3}, // TTF_HINTING_NONE
-        {"fontHeightReporting", 0},
+        {"fontHeightReporting", 1},
         {"fontOutlineCrop", true},
         {"rubyLoadpath", json::array({})},
         {"JITEnable", false},


### PR DESCRIPTION
@dpertierra reported a regression caused by the new default text height calculation method introduced in #283 that causes [this font](https://github.com/SkyFangames/La-Base-de-Sky/blob/1.2.0.1/LA%20BASE%20DE%20SKY/Fonts/power%20clear.ttf) to render with only the top half of the text visible. The original RPG Maker XP executable does not have this problem, so this is a bug.

This pull request changes the default height calculation back to the original one from before #283 until a more accurate way to calculate text height is implemented.

The bug may be reproduced with this script after downloading the font to the "Fonts" subdirectory of the game directory:

```ruby
text = 'Hello, World!'
bitmap = Bitmap.new(400, 400)
bitmap.font = Font.new('Power Clear', 100)
rect = bitmap.text_size(text)
bitmap.fill_rect(rect, Color.new(255, 0, 255, 255))
bitmap.fill_rect(Rect.new(rect.x + 1, rect.y + 1, rect.width - 2, rect.height - 2), Color.new(0, 0, 0, 255))
bitmap.draw_text(rect, text)
sprite = Sprite.new
sprite.bitmap = bitmap
loop do
  sprite.update
  Graphics.update
end
```

<img width="690" height="567" alt="screenshot" src="https://github.com/user-attachments/assets/d9c5aa6e-859d-4e02-8566-37b495a0bea5" />