### PR TITLE
Accept any object as a Boolean argument

### DIFF
--- a/binding/binding-util.h
+++ b/binding/binding-util.h
@@ -426,6 +426,10 @@ inline void rb_int_arg(VALUE arg, int *out, int argPos = 0) {
 }
 
 inline void rb_bool_arg(VALUE arg, bool *out, int argPos = 0) {
+    /* In all of the original Ruby-based RPG Maker runtimes, if a non-Boolean
+     * object is passed to a binding expecting a Boolean argument, such as the
+     * `visible=` method of the `Sprite` class, it should be cast to a Boolean
+     * by treating `false` and `nil` as falsy and everything else as truthy. */
     *out = arg != Qfalse && arg != Qnil;
 }
 

--- a/binding/binding-util.h
+++ b/binding/binding-util.h
@@ -426,19 +426,7 @@ inline void rb_int_arg(VALUE arg, int *out, int argPos = 0) {
 }
 
 inline void rb_bool_arg(VALUE arg, bool *out, int argPos = 0) {
-    switch (rb_type(arg)) {
-        case RUBY_T_TRUE:
-            *out = true;
-            break;
-            
-        case RUBY_T_FALSE:
-        case RUBY_T_NIL:
-            *out = false;
-            break;
-            
-        default:
-            throw Exception(Exception::TypeError, "Argument %d: Expected bool", argPos);
-    }
+    *out = arg != Qfalse && arg != Qnil;
 }
 
 /* rb_check_argc and rb_error_arity are both


### PR DESCRIPTION
In all Ruby-based RPG Maker versions, there isn't supposed to be an error if a non-Boolean object is passed to a binding that accepts a Boolean argument. It just gets converted to a Boolean using the typical implicit conversion: `false` and `nil` are considered to be falsy and all other objects are considered to be truthy. This pull request changes the behaviour of `rb_bool_arg()` to be consistent with this.