### PR TITLE
Add support for legacy delta bindings

### DIFF
--- a/binding/binding-mri.cpp
+++ b/binding/binding-mri.cpp
@@ -353,7 +353,7 @@ RB_METHOD(mkxpDelta) {
             case 1:
                 return rb_float_new(shState->runTime());
             case 2:
-                return RB_LONG2FIX(shState->runTime() * 1000000.0);
+                return RB_ULL2NUM(shState->runTime() * 1000000.0);
             default:
                 shState->config().delta = mkxp_use_legacy_delta() ? 2 : 1;
                 break;

--- a/binding/binding-mri.cpp
+++ b/binding/binding-mri.cpp
@@ -348,7 +348,17 @@ RB_METHOD_GUARD_END
 
 RB_METHOD(mkxpDelta) {
     RB_UNUSED_PARAM;
-    return rb_float_new(shState->runTime());
+    for (;;) {
+        switch (shState->config().delta) {
+            case 1:
+                return rb_float_new(shState->runTime());
+            case 2:
+                return RB_LONG2FIX(shState->runTime() * 1000000.0);
+            default:
+                shState->config().delta = mkxp_use_legacy_delta() ? 2 : 1;
+                break;
+        }
+    }
 }
 
 RB_METHOD(mkxpDataDirectory) {

--- a/binding/binding-util.cpp
+++ b/binding/binding-util.cpp
@@ -350,3 +350,19 @@ void *drop_gvl_guard(void *(*func)(void *), void *args,
 }
 
 #endif
+
+bool mkxp_use_legacy_delta() noexcept {
+  if (!rb_const_defined(rb_cObject, rb_intern("Essentials"))) {
+    return false;
+  }
+  VALUE value = rb_const_get(rb_cObject, rb_intern("Essentials"));
+  if (!rb_const_defined(value, rb_intern("VERSION"))) {
+    return false;
+  }
+  value = rb_const_get(value, rb_intern("VERSION"));
+  const char *version = rb_string_value_ptr(&value);
+  return strcmp(version, "19") == 0
+    || strcmp(version, "19.1") == 0
+    || strcmp(version, "20") == 0
+    || strcmp(version, "20.1") == 0;
+}

--- a/binding/binding-util.cpp
+++ b/binding/binding-util.cpp
@@ -360,6 +360,9 @@ bool mkxp_use_legacy_delta() noexcept {
     return false;
   }
   value = rb_const_get(value, rb_intern("VERSION"));
+  if (!RB_TYPE_P(value, RUBY_T_STRING)) {
+    return false;
+  }
   const char *version = rb_string_value_ptr(&value);
   return strcmp(version, "19") == 0
     || strcmp(version, "19.1") == 0

--- a/binding/binding-util.h
+++ b/binding/binding-util.h
@@ -718,4 +718,6 @@ DEF_GFX_PROP(Klass, double, PropName, float, rb_float_new)
 #define DEF_GFX_PROP_B(Klass, PropName)                                            \
 DEF_GFX_PROP(Klass, bool, PropName, bool, rb_bool_new)
 
+bool mkxp_use_legacy_delta() noexcept;
+
 #endif // BINDING_UTIL_H

--- a/binding/graphics-binding.cpp
+++ b/binding/graphics-binding.cpp
@@ -29,7 +29,22 @@
 RB_METHOD(graphicsDelta) {
     RB_UNUSED_PARAM;
     GFX_LOCK;
-    VALUE ret = rb_float_new(shState->graphics().getDelta());
+    VALUE ret;
+    for (bool running = true; running;) {
+        switch (shState->config().delta) {
+            case 1:
+                ret = rb_float_new(shState->graphics().getDelta());
+                running = false;
+                break;
+            case 2:
+                ret = RB_LONG2FIX(shState->graphics().getDelta() * 1000000.0);
+                running = false;
+                break;
+            default:
+                shState->config().delta = mkxp_use_legacy_delta() ? 2 : 1;
+                break;
+        }
+    }
     GFX_UNLOCK;
     return ret;
 }

--- a/binding/graphics-binding.cpp
+++ b/binding/graphics-binding.cpp
@@ -37,7 +37,7 @@ RB_METHOD(graphicsDelta) {
                 running = false;
                 break;
             case 2:
-                ret = RB_LONG2FIX(shState->graphics().getDelta() * 1000000.0);
+                ret = RB_ULL2NUM(shState->graphics().getDelta() * 1000000.0);
                 running = false;
                 break;
             default:

--- a/binding/input-binding.cpp
+++ b/binding/input-binding.cpp
@@ -33,8 +33,17 @@
 
 RB_METHOD(inputDelta) {
     RB_UNUSED_PARAM;
-    
-    return rb_float_new(shState->input().getDelta());
+    for (;;) {
+        switch (shState->config().delta) {
+            case 1:
+                return rb_float_new(shState->input().getDelta());
+            case 2:
+                return RB_LONG2FIX(shState->input().getDelta() * 1000000.0);
+            default:
+                shState->config().delta = mkxp_use_legacy_delta() ? 2 : 1;
+                break;
+        }
+    }
 }
 
 RB_METHOD_GUARD(inputUpdate) {

--- a/binding/input-binding.cpp
+++ b/binding/input-binding.cpp
@@ -38,7 +38,7 @@ RB_METHOD(inputDelta) {
             case 1:
                 return rb_float_new(shState->input().getDelta());
             case 2:
-                return RB_LONG2FIX(shState->input().getDelta() * 1000000.0);
+                return RB_ULL2NUM(shState->input().getDelta() * 1000000.0);
             default:
                 shState->config().delta = mkxp_use_legacy_delta() ? 2 : 1;
                 break;

--- a/mkxp.json
+++ b/mkxp.json
@@ -572,4 +572,12 @@
     //
     // "dumpAtlas": false,
 
+
+    // Controls what units the `Graphics.delta`, `Input.delta`, `System.delta` and `System.uptime` functions return.
+    // 0: Automatically detect whether 1 or 2 should be used for the current game, defaulting to 1 if the autodetection failed.
+    // 1: The functions return time in seconds as a `Float`.
+    // 2: The functions return time in microseconds as an `Integer`.
+    // (default: 0)
+    //
+    // "delta": 0,
 }

--- a/mkxp.json
+++ b/mkxp.json
@@ -42,6 +42,15 @@
     // "rgssVersion": 1,
 
 
+    // Controls what units the `Graphics.delta`, `Input.delta`, `System.delta` and `System.uptime` functions return.
+    // 0: Automatically detect whether 1 or 2 should be used for the current game, defaulting to 1 if the autodetection failed.
+    // 1: The functions return time in seconds as a `Float`.
+    // 2: The functions return time in microseconds as an `Integer`.
+    // (default: 0)
+    //
+    // "delta": 0,
+
+
     // Continuously display average FPS in window title.
     // This can always be toggled with F2 at runtime.
     // (default: disabled)
@@ -572,12 +581,4 @@
     //
     // "dumpAtlas": false,
 
-
-    // Controls what units the `Graphics.delta`, `Input.delta`, `System.delta` and `System.uptime` functions return.
-    // 0: Automatically detect whether 1 or 2 should be used for the current game, defaulting to 1 if the autodetection failed.
-    // 1: The functions return time in seconds as a `Float`.
-    // 2: The functions return time in microseconds as an `Integer`.
-    // (default: 0)
-    //
-    // "delta": 0,
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -212,7 +212,8 @@ void Config::read(int argc, char *argv[]) {
             {"z", "Z"},
             {"l", "L"},
             {"r", "R"}
-        })}
+        })},
+        {"legacyDelta", 0},
     });
     
     auto &opts = optsJ.as_object();
@@ -320,6 +321,7 @@ try { exp } catch (...) {}
     SET_STRINGOPT(customScript, customScript);
     SET_OPT(useScriptNames, boolean);
     SET_OPT(dumpAtlas, boolean);
+    SET_OPT(delta, integer);
     
     fillStringVec(opts["preloadScript"], preloadScripts);
     fillStringVec(opts["postloadScript"], postloadScripts);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -128,6 +128,7 @@ Config::Config() {}
 void Config::read(int argc, char *argv[]) {
     auto optsJ = json::object({
         {"rgssVersion", 0},
+        {"delta", 0},
         {"debugMode", false},
         {"displayFPS", false},
         {"printFPS", false},
@@ -212,8 +213,7 @@ void Config::read(int argc, char *argv[]) {
             {"z", "Z"},
             {"l", "L"},
             {"r", "R"}
-        })},
-        {"legacyDelta", 0},
+        })}
     });
     
     auto &opts = optsJ.as_object();
@@ -257,6 +257,7 @@ try { exp } catch (...) {}
     SET_OPT_CUSTOMKEY(jit.minCalls, JITMinCalls, integer);
     SET_OPT_CUSTOMKEY(yjit.enabled, YJITEnable, boolean);
     SET_OPT(rgssVersion, integer);
+    SET_OPT(delta, integer);
     SET_OPT(defScreenW, integer);
     SET_OPT(defScreenH, integer);
     
@@ -321,7 +322,6 @@ try { exp } catch (...) {}
     SET_STRINGOPT(customScript, customScript);
     SET_OPT(useScriptNames, boolean);
     SET_OPT(dumpAtlas, boolean);
-    SET_OPT(delta, integer);
     
     fillStringVec(opts["preloadScript"], preloadScripts);
     fillStringVec(opts["postloadScript"], postloadScripts);

--- a/src/config.h
+++ b/src/config.h
@@ -169,6 +169,8 @@ struct Config {
     
     std::string userConfPath;
     
+    int delta;
+    
     /* Internal */
     std::string customDataPath;
     

--- a/src/config.h
+++ b/src/config.h
@@ -33,6 +33,7 @@ struct Config {
     json5pp::value raw;
     
     int rgssVersion;
+    int delta;
     
     bool debugMode;
     bool winConsole;
@@ -168,8 +169,6 @@ struct Config {
     } kbActionNames;
     
     std::string userConfPath;
-    
-    int delta;
     
     /* Internal */
     std::string customDataPath;


### PR DESCRIPTION
`Graphics.delta`, `Input.delta`, `System.delta` and `System.uptime` were changed in a backwards-incompatible way in https://github.com/mkxp-z/mkxp-z/commit/0072c193716aa70d3fd375d7f001322d09699bec. Originally these functions returned an integer number of microseconds, but now they return a floating-point number of seconds. However, games made with Pokémon Essentials versions 19, 19.1, 20 and 20.1 need the old integer number of microseconds return value to work correctly.

For example, the Pokémon Essentials 19.1 game [Solace](https://eeveeexpo.com/solace/) uses `Graphics.delta` to add delay between the scenes in its opening cutscene. With the new behaviour, the delays take 1000000 times as long, resulting in the game appearing to freeze in its unfortunately unskippable opening cutscene.

I've added a `delta` option to mkxp.json to control whether the old behaviour or new behaviour should be used, or to autodetect which should be used.