### PR TITLE
Fix some minor problems with win32_wrap.rb

### DIFF
--- a/binding/input-binding.cpp
+++ b/binding/input-binding.cpp
@@ -31,16 +31,36 @@
 #include "sharedstate.h"
 #include "src/util/util.h"
 
+static VALUE module;
+static VALUE submod;
+static VALUE klass;
+
+#if RAPI_FULL > 187
+DEF_TYPE(Input);
+#else
+DEF_ALLOCFUNC(Input);
+#endif
+
+RB_METHOD(inputInitialize) {
+    RB_UNUSED_PARAM;
+    setPrivateData(self, new Input(shState->rtData()));
+    return self;
+}
+
+static Input &getInput(VALUE self) {
+    return self == module || self == submod ? shState->input() : *getPrivateDataCheck<Input>(self, InputType);
+}
+
 RB_METHOD(inputDelta) {
     RB_UNUSED_PARAM;
     
-    return rb_float_new(shState->input().getDelta());
+    return rb_float_new(getInput(self).getDelta());
 }
 
 RB_METHOD_GUARD(inputUpdate) {
     RB_UNUSED_PARAM;
     
-    shState->input().update();
+    getInput(self).update();
     
     return Qnil;
 }
@@ -105,7 +125,7 @@ RB_METHOD(inputPress) {
     
     int num = getButtonArg(&button);
     
-    return rb_bool_new(shState->input().isPressed(num));
+    return rb_bool_new(getInput(self).isPressed(num));
 }
 
 RB_METHOD(inputTrigger) {
@@ -118,7 +138,7 @@ RB_METHOD(inputTrigger) {
     
     int num = getButtonArg(&button);
     
-    return rb_bool_new(shState->input().isTriggered(num));
+    return rb_bool_new(getInput(self).isTriggered(num));
 }
 
 RB_METHOD(inputRepeat) {
@@ -131,7 +151,7 @@ RB_METHOD(inputRepeat) {
     
     int num = getButtonArg(&button);
     
-    return rb_bool_new(shState->input().isRepeated(num));
+    return rb_bool_new(getInput(self).isRepeated(num));
 }
 
 RB_METHOD(inputRelease) {
@@ -144,7 +164,7 @@ RB_METHOD(inputRelease) {
     
     int num = getButtonArg(&button);
     
-    return rb_bool_new(shState->input().isReleased(num));
+    return rb_bool_new(getInput(self).isReleased(num));
 }
 
 RB_METHOD(inputCount) {
@@ -157,7 +177,7 @@ RB_METHOD(inputCount) {
     
     int num = getButtonArg(&button);
     
-    return UINT2NUM(shState->input().count(num));
+    return UINT2NUM(getInput(self).count(num));
 }
 
 RB_METHOD(inputRepeatTime) {
@@ -170,7 +190,7 @@ RB_METHOD(inputRepeatTime) {
     
     int num = getButtonArg(&button);
     
-    return rb_float_new(shState->input().repeatTime(num));
+    return rb_float_new(getInput(self).repeatTime(num));
 }
 
 RB_METHOD_GUARD(inputPressEx) {
@@ -181,10 +201,10 @@ RB_METHOD_GUARD(inputPressEx) {
     
     if (SYMBOL_P(button)) {
         int num = getScancodeArg(&button);
-        return rb_bool_new(shState->input().isPressedEx(num, 0));
+        return rb_bool_new(getInput(self).isPressedEx(num, 0));
     }
     
-    return rb_bool_new(shState->input().isPressedEx(NUM2INT(button), 1));
+    return rb_bool_new(getInput(self).isPressedEx(NUM2INT(button), 1));
 }
 RB_METHOD_GUARD_END
 
@@ -196,10 +216,10 @@ RB_METHOD_GUARD(inputTriggerEx) {
     
     if (SYMBOL_P(button)) {
         int num = getScancodeArg(&button);
-        return rb_bool_new(shState->input().isTriggeredEx(num, 0));
+        return rb_bool_new(getInput(self).isTriggeredEx(num, 0));
     }
     
-    return rb_bool_new(shState->input().isTriggeredEx(NUM2INT(button), 1));
+    return rb_bool_new(getInput(self).isTriggeredEx(NUM2INT(button), 1));
 }
 RB_METHOD_GUARD_END
 
@@ -211,10 +231,10 @@ RB_METHOD_GUARD(inputRepeatEx) {
     
     if (SYMBOL_P(button)) {
         int num = getScancodeArg(&button);
-        return rb_bool_new(shState->input().isRepeatedEx(num, 0));
+        return rb_bool_new(getInput(self).isRepeatedEx(num, 0));
     }
     
-    return rb_bool_new(shState->input().isRepeatedEx(NUM2INT(button), 1));
+    return rb_bool_new(getInput(self).isRepeatedEx(NUM2INT(button), 1));
 }
 RB_METHOD_GUARD_END
 
@@ -226,10 +246,10 @@ RB_METHOD_GUARD(inputReleaseEx) {
     
     if (SYMBOL_P(button)) {
         int num = getScancodeArg(&button);
-        return rb_bool_new(shState->input().isReleasedEx(num, 0));
+        return rb_bool_new(getInput(self).isReleasedEx(num, 0));
     }
     
-    return rb_bool_new(shState->input().isReleasedEx(NUM2INT(button), 1));
+    return rb_bool_new(getInput(self).isReleasedEx(NUM2INT(button), 1));
 }
 RB_METHOD_GUARD_END
 
@@ -241,10 +261,10 @@ RB_METHOD_GUARD(inputCountEx) {
     
     if (SYMBOL_P(button)) {
         int num = getScancodeArg(&button);
-        return UINT2NUM(shState->input().repeatcount(num, 0));
+        return UINT2NUM(getInput(self).repeatcount(num, 0));
     }
     
-    return UINT2NUM(shState->input().repeatcount(NUM2INT(button), 1));
+    return UINT2NUM(getInput(self).repeatcount(NUM2INT(button), 1));
 }
 RB_METHOD_GUARD_END
 
@@ -256,48 +276,48 @@ RB_METHOD_GUARD(inputRepeatTimeEx) {
     
     if (SYMBOL_P(button)) {
         int num = getScancodeArg(&button);
-        return rb_float_new(shState->input().repeatTimeEx(num, 0));
+        return rb_float_new(getInput(self).repeatTimeEx(num, 0));
     }
     
-    return rb_float_new(shState->input().repeatTimeEx(NUM2INT(button), 1));
+    return rb_float_new(getInput(self).repeatTimeEx(NUM2INT(button), 1));
 }
 RB_METHOD_GUARD_END
 
 RB_METHOD(inputDir4) {
     RB_UNUSED_PARAM;
     
-    return rb_fix_new(shState->input().dir4Value());
+    return rb_fix_new(getInput(self).dir4Value());
 }
 
 RB_METHOD(inputDir8) {
     RB_UNUSED_PARAM;
     
-    return rb_fix_new(shState->input().dir8Value());
+    return rb_fix_new(getInput(self).dir8Value());
 }
 
 /* Non-standard extensions */
 RB_METHOD(inputMouseX) {
     RB_UNUSED_PARAM;
     
-    return rb_fix_new(shState->input().mouseX());
+    return rb_fix_new(getInput(self).mouseX());
 }
 
 RB_METHOD(inputMouseY) {
     RB_UNUSED_PARAM;
     
-    return rb_fix_new(shState->input().mouseY());
+    return rb_fix_new(getInput(self).mouseY());
 }
 
 RB_METHOD(inputScrollV) {
     RB_UNUSED_PARAM;
     
-    return rb_fix_new(shState->input().scrollV());
+    return rb_fix_new(getInput(self).scrollV());
 }
 
 RB_METHOD(inputMouseInWindow) {
     RB_UNUSED_PARAM;
     
-    return rb_bool_new(shState->input().mouseInWindow());
+    return rb_bool_new(getInput(self).mouseInWindow());
 }
 
 RB_METHOD(inputRawKeyStates) {
@@ -305,9 +325,9 @@ RB_METHOD(inputRawKeyStates) {
     
     VALUE ret = rb_ary_new();
 
-    uint8_t *states = shState->input().rawKeyStates();
+    uint8_t *states = getInput(self).rawKeyStates();
     
-    for (unsigned int i = 0; i < shState->input().rawKeyStatesLength(); i++)
+    for (unsigned int i = 0; i < getInput(self).rawKeyStatesLength(); i++)
         rb_ary_push(ret, rb_bool_new(states[i]));
     
     return ret;
@@ -322,16 +342,16 @@ break;
 RB_METHOD(inputControllerConnected) {
     RB_UNUSED_PARAM;
     
-    return rb_bool_new(shState->input().getControllerConnected());
+    return rb_bool_new(getInput(self).getControllerConnected());
 }
 
 RB_METHOD(inputControllerName) {
     RB_UNUSED_PARAM;
     
-    if (!shState->input().getControllerConnected())
+    if (!getInput(self).getControllerConnected())
         return rb_utf8_str_new_cstr("");
     
-    return rb_utf8_str_new_cstr(shState->input().getControllerName());
+    return rb_utf8_str_new_cstr(getInput(self).getControllerName());
 }
 
 RB_METHOD(inputControllerPowerLevel) {
@@ -339,10 +359,10 @@ RB_METHOD(inputControllerPowerLevel) {
     
     VALUE ret;
     
-    if (!shState->input().getControllerConnected())
+    if (!getInput(self).getControllerConnected())
         ret = M_SYMBOL("UNKNOWN");
     
-    switch (shState->input().getControllerPowerLevel()) {
+    switch (getInput(self).getControllerPowerLevel()) {
             POWERCASE(ret, MAX);
             POWERCASE(ret, WIRED);
             POWERCASE(ret, FULL);
@@ -365,8 +385,8 @@ VALUE ret = rb_ary_new(); \
 if (!shState->eThread().getControllerConnected()) {\
 rb_ary_push(ret, rb_float_new(0)); rb_ary_push(ret, rb_float_new(0)); \
 }\
-rb_ary_push(ret, rb_float_new(shState->input().getControllerAxisValue(SDL_CONTROLLER_AXIS_##ax1) / 32767.0)); \
-rb_ary_push(ret, rb_float_new(shState->input().getControllerAxisValue(SDL_CONTROLLER_AXIS_##ax2) / 32767.0)); \
+rb_ary_push(ret, rb_float_new(getInput(self).getControllerAxisValue(SDL_CONTROLLER_AXIS_##ax1) / 32767.0)); \
+rb_ary_push(ret, rb_float_new(getInput(self).getControllerAxisValue(SDL_CONTROLLER_AXIS_##ax2) / 32767.0)); \
 return ret; \
 }
 
@@ -385,10 +405,10 @@ RB_METHOD_GUARD(inputControllerPressEx) {
     
     if (SYMBOL_P(button)) {
         int num = getControllerButtonArg(&button);
-        return rb_bool_new(shState->input().controllerIsPressedEx(num));
+        return rb_bool_new(getInput(self).controllerIsPressedEx(num));
     }
     
-    return rb_bool_new(shState->input().controllerIsPressedEx(NUM2INT(button)));
+    return rb_bool_new(getInput(self).controllerIsPressedEx(NUM2INT(button)));
 }
 RB_METHOD_GUARD_END
 
@@ -400,10 +420,10 @@ RB_METHOD_GUARD(inputControllerTriggerEx) {
     
     if (SYMBOL_P(button)) {
         int num = getControllerButtonArg(&button);
-        return rb_bool_new(shState->input().controllerIsTriggeredEx(num));
+        return rb_bool_new(getInput(self).controllerIsTriggeredEx(num));
     }
     
-    return rb_bool_new(shState->input().controllerIsTriggeredEx(NUM2INT(button)));
+    return rb_bool_new(getInput(self).controllerIsTriggeredEx(NUM2INT(button)));
 }
 RB_METHOD_GUARD_END
 
@@ -415,10 +435,10 @@ RB_METHOD_GUARD(inputControllerRepeatEx) {
     
     if (SYMBOL_P(button)) {
         int num = getControllerButtonArg(&button);
-        return rb_bool_new(shState->input().controllerIsRepeatedEx(num));
+        return rb_bool_new(getInput(self).controllerIsRepeatedEx(num));
     }
     
-    return rb_bool_new(shState->input().controllerIsRepeatedEx(NUM2INT(button)));
+    return rb_bool_new(getInput(self).controllerIsRepeatedEx(NUM2INT(button)));
 }
 RB_METHOD_GUARD_END
 
@@ -430,10 +450,10 @@ RB_METHOD_GUARD(inputControllerReleaseEx) {
     
     if (SYMBOL_P(button)) {
         int num = getControllerButtonArg(&button);
-        return rb_bool_new(shState->input().controllerIsReleasedEx(num));
+        return rb_bool_new(getInput(self).controllerIsReleasedEx(num));
     }
     
-    return rb_bool_new(shState->input().controllerIsReleasedEx(NUM2INT(button)));
+    return rb_bool_new(getInput(self).controllerIsReleasedEx(NUM2INT(button)));
 }
 RB_METHOD_GUARD_END
 
@@ -445,10 +465,10 @@ RB_METHOD_GUARD(inputControllerCountEx) {
     
     if (SYMBOL_P(button)) {
         int num = getControllerButtonArg(&button);
-        return rb_bool_new(shState->input().controllerRepeatcount(num));
+        return rb_bool_new(getInput(self).controllerRepeatcount(num));
     }
     
-    return rb_bool_new(shState->input().controllerRepeatcount(NUM2INT(button)));
+    return rb_bool_new(getInput(self).controllerRepeatcount(NUM2INT(button)));
 }
 RB_METHOD_GUARD_END
 
@@ -460,10 +480,10 @@ RB_METHOD_GUARD(inputControllerRepeatTimeEx) {
     
     if (SYMBOL_P(button)) {
         int num = getControllerButtonArg(&button);
-        return rb_float_new(shState->input().controllerRepeatTimeEx(num));
+        return rb_float_new(getInput(self).controllerRepeatTimeEx(num));
     }
     
-    return rb_float_new(shState->input().controllerRepeatTimeEx(NUM2INT(button)));
+    return rb_float_new(getInput(self).controllerRepeatTimeEx(NUM2INT(button)));
 }
 RB_METHOD_GUARD_END
 
@@ -471,9 +491,9 @@ RB_METHOD(inputControllerRawButtonStates) {
     RB_UNUSED_PARAM;
     
     VALUE ret = rb_ary_new();
-    uint8_t *states = shState->input().rawButtonStates();
+    uint8_t *states = getInput(self).rawButtonStates();
     
-    for (unsigned int i = 0; i < shState->input().rawButtonStatesLength(); i++)
+    for (unsigned int i = 0; i < getInput(self).rawButtonStatesLength(); i++)
         rb_ary_push(ret, rb_bool_new(states[i]));
     
     return ret;
@@ -483,9 +503,9 @@ RB_METHOD(inputControllerRawAxes) {
     RB_UNUSED_PARAM;
     
     VALUE ret = rb_ary_new();
-    int16_t *states = shState->input().rawAxes();
+    int16_t *states = getInput(self).rawAxes();
     
-    for (unsigned int i = 0; i < shState->input().rawAxesLength(); i++)
+    for (unsigned int i = 0; i < getInput(self).rawAxesLength(); i++)
         rb_ary_push(ret, rb_float_new(states[i] / 32767.0));
     
     return ret;
@@ -494,7 +514,7 @@ RB_METHOD(inputControllerRawAxes) {
 RB_METHOD(inputGetMode) {
     RB_UNUSED_PARAM;
     
-    return rb_bool_new(shState->input().getTextInputMode());
+    return rb_bool_new(getInput(self).getTextInputMode());
 }
 
 RB_METHOD(inputSetMode) {
@@ -503,7 +523,7 @@ RB_METHOD(inputSetMode) {
     bool mode;
     rb_get_args(argc, argv, "b", &mode RB_ARG_END);
     
-    shState->input().setTextInputMode(mode);
+    getInput(self).setTextInputMode(mode);
     
     return mode;
 }
@@ -511,15 +531,15 @@ RB_METHOD(inputSetMode) {
 RB_METHOD(inputGets) {
     RB_UNUSED_PARAM;
     shState->eThread().lockText(true);
-    VALUE ret = rb_utf8_str_new_cstr(shState->input().getText());
-    shState->input().clearText();
+    VALUE ret = rb_utf8_str_new_cstr(getInput(self).getText());
+    getInput(self).clearText();
     shState->eThread().lockText(false);
     return ret;
 }
 
 RB_METHOD_GUARD(inputGetClipboard) {
     RB_UNUSED_PARAM;
-    return rb_utf8_str_new_cstr(shState->input().getClipboardText());
+    return rb_utf8_str_new_cstr(getInput(self).getClipboardText());
 }
 RB_METHOD_GUARD_END
 
@@ -531,7 +551,7 @@ RB_METHOD_GUARD(inputSetClipboard) {
     
     SafeStringValue(str);
     
-    shState->input().setClipboardText(RSTRING_PTR(str));
+    getInput(self).setClipboardText(RSTRING_PTR(str));
     
     return str;
 }
@@ -570,57 +590,74 @@ struct {
 
 static elementsN(buttonCodes);
 
+#define DEFINE_INPUT_BINDING(name, function) do { \
+    _rb_define_module_function(module, #name, function); \
+    _rb_define_method(klass, #name, function); \
+} while (0)
+
+#define DEFINE_CONTROLLER_BINDING(name, function) do { \
+    _rb_define_module_function(submod, #name, function); \
+    _rb_define_method(klass, "controller_" #name, function); \
+} while (0)
+
 void inputBindingInit() {
-    VALUE module = rb_define_module("Input");
-    
-    _rb_define_module_function(module, "delta", inputDelta);
-    _rb_define_module_function(module, "update", inputUpdate);
-    _rb_define_module_function(module, "press?", inputPress);
-    _rb_define_module_function(module, "trigger?", inputTrigger);
-    _rb_define_module_function(module, "repeat?", inputRepeat);
-    _rb_define_module_function(module, "release?", inputRelease);
-    _rb_define_module_function(module, "count", inputCount);
-    _rb_define_module_function(module, "time?", inputRepeatTime);
-    _rb_define_module_function(module, "pressex?", inputPressEx);
-    _rb_define_module_function(module, "triggerex?", inputTriggerEx);
-    _rb_define_module_function(module, "repeatex?", inputRepeatEx);
-    _rb_define_module_function(module, "releaseex?", inputReleaseEx);
-    _rb_define_module_function(module, "repeatcount", inputCountEx);
-    _rb_define_module_function(module, "timeex?", inputRepeatTimeEx);
-    _rb_define_module_function(module, "dir4", inputDir4);
-    _rb_define_module_function(module, "dir8", inputDir8);
-    
-    _rb_define_module_function(module, "mouse_x", inputMouseX);
-    _rb_define_module_function(module, "mouse_y", inputMouseY);
-    _rb_define_module_function(module, "scroll_v", inputScrollV);
-    _rb_define_module_function(module, "mouse_in_window", inputMouseInWindow);
-    _rb_define_module_function(module, "mouse_in_window?", inputMouseInWindow);
-    
-    _rb_define_module_function(module, "raw_key_states", inputRawKeyStates);
-    
-    VALUE submod = rb_define_module_under(module, "Controller");
-    _rb_define_module_function(submod, "connected?", inputControllerConnected);
-    _rb_define_module_function(submod, "name", inputControllerName);
-    _rb_define_module_function(submod, "power_level", inputControllerPowerLevel);
-    _rb_define_module_function(submod, "axes_left", inputControllerGetLeftAxis);
-    _rb_define_module_function(submod, "axes_right", inputControllerGetRightAxis);
-    _rb_define_module_function(submod, "axes_trigger", inputControllerGetTriggerAxis);
-    _rb_define_module_function(submod, "raw_button_states", inputControllerRawButtonStates);
-    _rb_define_module_function(submod, "raw_axes", inputControllerRawAxes);
-    _rb_define_module_function(submod, "pressex?", inputControllerPressEx);
-    _rb_define_module_function(submod, "triggerex?", inputControllerTriggerEx);
-    _rb_define_module_function(submod, "repeatex?", inputControllerRepeatEx);
-    _rb_define_module_function(submod, "releaseex?", inputControllerReleaseEx);
-    _rb_define_module_function(submod, "repeatcount", inputControllerCountEx);
-    _rb_define_module_function(submod, "timeex?", inputControllerRepeatTimeEx);
-    
-    _rb_define_module_function(module, "text_input", inputGetMode);
-    _rb_define_module_function(module, "text_input=", inputSetMode);
-    _rb_define_module_function(module, "gets", inputGets);
-    
-    _rb_define_module_function(module, "clipboard", inputGetClipboard);
-    _rb_define_module_function(module, "clipboard=", inputSetClipboard);
-    
+    module = rb_define_module("Input");
+    klass = rb_define_class("InputInstance", rb_cObject);
+#if RAPI_FULL > 187
+    rb_define_alloc_func(klass, classAllocate<&InputType>);
+#else
+    rb_define_alloc_func(klass, InputAllocate);
+#endif
+    _rb_define_method(klass, "initialize", inputInitialize);
+
+    DEFINE_INPUT_BINDING(delta, inputDelta);
+    DEFINE_INPUT_BINDING(update, inputUpdate);
+    DEFINE_INPUT_BINDING(press?, inputPress);
+    DEFINE_INPUT_BINDING(trigger?, inputTrigger);
+    DEFINE_INPUT_BINDING(repeat?, inputRepeat);
+    DEFINE_INPUT_BINDING(release?, inputRelease);
+    DEFINE_INPUT_BINDING(count, inputCount);
+    DEFINE_INPUT_BINDING(time?, inputRepeatTime);
+    DEFINE_INPUT_BINDING(pressex?, inputPressEx);
+    DEFINE_INPUT_BINDING(triggerex?, inputTriggerEx);
+    DEFINE_INPUT_BINDING(repeatex?, inputRepeatEx);
+    DEFINE_INPUT_BINDING(releaseex?, inputReleaseEx);
+    DEFINE_INPUT_BINDING(repeatcount, inputCountEx);
+    DEFINE_INPUT_BINDING(timeex?, inputRepeatTimeEx);
+    DEFINE_INPUT_BINDING(dir4, inputDir4);
+    DEFINE_INPUT_BINDING(dir8, inputDir8);
+
+    DEFINE_INPUT_BINDING(mouse_x, inputMouseX);
+    DEFINE_INPUT_BINDING(mouse_y, inputMouseY);
+    DEFINE_INPUT_BINDING(scroll_v, inputScrollV);
+    DEFINE_INPUT_BINDING(mouse_in_window, inputMouseInWindow);
+    DEFINE_INPUT_BINDING(mouse_in_window?, inputMouseInWindow);
+
+    DEFINE_INPUT_BINDING(raw_key_states, inputRawKeyStates);
+
+    submod = rb_define_module_under(module, "Controller");
+    DEFINE_CONTROLLER_BINDING(connected?, inputControllerConnected);
+    DEFINE_CONTROLLER_BINDING(name, inputControllerName);
+    DEFINE_CONTROLLER_BINDING(power_level, inputControllerPowerLevel);
+    DEFINE_CONTROLLER_BINDING(axes_left, inputControllerGetLeftAxis);
+    DEFINE_CONTROLLER_BINDING(axes_right, inputControllerGetRightAxis);
+    DEFINE_CONTROLLER_BINDING(axes_trigger, inputControllerGetTriggerAxis);
+    DEFINE_CONTROLLER_BINDING(raw_button_states, inputControllerRawButtonStates);
+    DEFINE_CONTROLLER_BINDING(raw_axes, inputControllerRawAxes);
+    DEFINE_CONTROLLER_BINDING(pressex?, inputControllerPressEx);
+    DEFINE_CONTROLLER_BINDING(triggerex?, inputControllerTriggerEx);
+    DEFINE_CONTROLLER_BINDING(repeatex?, inputControllerRepeatEx);
+    DEFINE_CONTROLLER_BINDING(releaseex?, inputControllerReleaseEx);
+    DEFINE_CONTROLLER_BINDING(repeatcount, inputControllerCountEx);
+    DEFINE_CONTROLLER_BINDING(timeex?, inputControllerRepeatTimeEx);
+
+    DEFINE_INPUT_BINDING(text_input, inputGetMode);
+    DEFINE_INPUT_BINDING(text_input=, inputSetMode);
+    DEFINE_INPUT_BINDING(gets, inputGets);
+
+    DEFINE_INPUT_BINDING(clipboard, inputGetClipboard);
+    DEFINE_INPUT_BINDING(clipboard=, inputSetClipboard);
+
     if (rgssVer >= 3) {
         VALUE symHash = rb_hash_new();
         

--- a/binding/input-binding.cpp
+++ b/binding/input-binding.cpp
@@ -31,10 +31,6 @@
 #include "sharedstate.h"
 #include "src/util/util.h"
 
-static VALUE module;
-static VALUE submod;
-static VALUE klass;
-
 #if RAPI_FULL > 187
 DEF_TYPE(Input);
 #else
@@ -48,7 +44,7 @@ RB_METHOD(inputInitialize) {
 }
 
 static Input &getInput(VALUE self) {
-    return self == module || self == submod ? shState->input() : *getPrivateDataCheck<Input>(self, InputType);
+    return rb_typeddata_is_kind_of(self, &InputType) ? *getPrivateDataNoRaise<Input>(self) : shState->input();
 }
 
 RB_METHOD(inputDelta) {
@@ -601,8 +597,8 @@ static elementsN(buttonCodes);
 } while (0)
 
 void inputBindingInit() {
-    module = rb_define_module("Input");
-    klass = rb_define_class("InputInstance", rb_cObject);
+    VALUE module = rb_define_module("Input");
+    VALUE klass = rb_define_class("InputInstance", rb_cObject);
 #if RAPI_FULL > 187
     rb_define_alloc_func(klass, classAllocate<&InputType>);
 #else
@@ -635,7 +631,7 @@ void inputBindingInit() {
 
     DEFINE_INPUT_BINDING(raw_key_states, inputRawKeyStates);
 
-    submod = rb_define_module_under(module, "Controller");
+    VALUE submod = rb_define_module_under(module, "Controller");
     DEFINE_CONTROLLER_BINDING(connected?, inputControllerConnected);
     DEFINE_CONTROLLER_BINDING(name, inputControllerName);
     DEFINE_CONTROLLER_BINDING(power_level, inputControllerPowerLevel);

--- a/scripts/preload/win32_wrap.rb
+++ b/scripts/preload/win32_wrap.rb
@@ -19,6 +19,11 @@
 # TOLERATE_ERRORS=false
 # LOG_NATIVE=true
 
+unless Win32API.method_defined? :mkxp_native_call
+
+$win32Input = Input
+$win32InputInstance = InputInstance.new
+
 module Scancodes
 	SDL = { :UNKNOWN => 0x00,
 		:A => 0x04, :B => 0x05, :C => 0x06, :D => 0x07,
@@ -169,6 +174,7 @@ module Graphics
 		alias_method(:win32wrap_update, :update)
 		def update
 			win32wrap_update
+			$win32InputInstance.update
 			$win32KeyStates = nil
 		end
 	end
@@ -176,7 +182,7 @@ end
 
 def get_raw_keystates
 	if $win32KeyStates == nil
-		$win32KeyStates = Input.raw_key_states
+		$win32KeyStates = $win32InputInstance.raw_key_states
 	end
 
 	return $win32KeyStates
@@ -189,11 +195,11 @@ def common_keystate(vkey)
 	pressed = false
 
 	if vkey_name == :LBUTTON
-		pressed = Input.press?(Input::MOUSELEFT)
+		pressed = $win32InputInstance.press?($win32Input::MOUSELEFT)
 	elsif vkey_name == :RBUTTON
-		pressed = Input.press?(Input::MOUSERIGHT)
+		pressed = $win32InputInstance.press?($win32Input::MOUSERIGHT)
 	elsif vkey_name == :MBUTTON
-		pressed = Input.press?(Input::MOUSEMIDDLE)
+		pressed = $win32InputInstance.press?($win32Input::MOUSEMIDDLE)
 	elsif vkey_name == :SHIFT
 		pressed = double_state(states, :LSHIFT, :RSHIFT)
 	elsif vkey_name == :MENU
@@ -304,7 +310,7 @@ module Win32API_Impl
 
 		class GetCursorPos
 			def call(args)
-				out = [Input.mouse_x, Input.mouse_y].pack('ll')
+				out = [$win32InputInstance.mouse_x, $win32InputInstance.mouse_y].pack('ll')
 				memcpy_string(args[0], out)
 				return 1
 			end
@@ -361,14 +367,17 @@ class Win32API
 		dll = kappatalize(dll.chomp(".dll"))
 		func = kappatalize(func)
 
-		if !System.is_windows? or !NATIVE_ON_WINDOWS
-			if Win32API_Impl.const_defined?(dll)
-				dll_impl = Win32API_Impl.const_get(dll)
-				if dll_impl.const_defined?(func)
-					@mkxp_wrap_impl = dll_impl.const_get(func).new
-					return
+		begin
+			if !System.is_windows? or !NATIVE_ON_WINDOWS
+				if Win32API_Impl.const_defined?(dll)
+					dll_impl = Win32API_Impl.const_get(dll)
+					if dll_impl.const_defined?(func)
+						@mkxp_wrap_impl = dll_impl.const_get(func).new
+						return
+					end
 				end
 			end
+		rescue Exception
 		end
 
 		@mkxp_native_available = false
@@ -376,7 +385,7 @@ class Win32API
 			mkxp_native_initialize(@dll, @func, *args)
 			@mkxp_native_available = true
 			return
-		rescue
+		rescue Exception
 		end
 
 	end
@@ -402,4 +411,6 @@ class Win32API
 			raise RuntimeError, "[Win32API] [#{@dll}:#{@func}] #{args.to_s}"
 		end
 	end
+end
+
 end

--- a/scripts/preload/win32_wrap.rb
+++ b/scripts/preload/win32_wrap.rb
@@ -21,8 +21,10 @@
 
 unless Win32API.method_defined? :mkxp_native_call
 
-$win32Input = Input
+$win32Graphics = Graphics.dup
+$win32Input = Input.dup
 $win32InputInstance = InputInstance.new
+$win32System = System.dup
 
 module Scancodes
 	SDL = { :UNKNOWN => 0x00,
@@ -263,7 +265,7 @@ module Win32API_Impl
 
 				if @index == 4
 					@index = 0
-					Graphics.fullscreen = !Graphics.fullscreen
+					$win32Graphics.fullscreen = !$win32Graphics.fullscreen
 				end
 			end
 		end
@@ -304,7 +306,7 @@ module Win32API_Impl
 					@cursor_count -= 1
 				end
 
-				Graphics.show_cursor = @cursor_count >= 0
+				$win32Graphics.show_cursor = @cursor_count >= 0
 			end
 		end
 
@@ -321,8 +323,8 @@ module Win32API_Impl
 				return 0 if args[0] != 42
 				rect = [0, 0, 640, 480]
 				begin
-					rect[2] = Graphics.width
-					rect[3] = Graphics.height
+					rect[2] = $win32Graphics.width
+					rect[3] = $win32Graphics.height
 				rescue
 				end
 				memcpy_string(args[1], rect.pack('l4'))
@@ -368,7 +370,7 @@ class Win32API
 		func = kappatalize(func)
 
 		begin
-			if !System.is_windows? or !NATIVE_ON_WINDOWS
+			if !$win32System.is_windows? or !NATIVE_ON_WINDOWS
 				if Win32API_Impl.const_defined?(dll)
 					dll_impl = Win32API_Impl.const_get(dll)
 					if dll_impl.const_defined?(func)
@@ -398,13 +400,13 @@ class Win32API
 
 		if @mkxp_native_available
 			if LOG_NATIVE
-				System.puts("[Win32API] [#{@dll}:#{@func}] #{args.to_s}")
+				$win32System.puts("[Win32API] [#{@dll}:#{@func}] #{args.to_s}")
 			end
 			return mkxp_native_call(*args)
 		end
 
 		if TOLERATE_ERRORS
-			System.puts("[Win32API] [#{@dll}:#{@func}] #{args.to_s}") if !@called
+			$win32System.puts("[Win32API] [#{@dll}:#{@func}] #{args.to_s}") if !@called
 			@called = true
 			return 0
 		else

--- a/src/input/input.h
+++ b/src/input/input.h
@@ -116,10 +116,10 @@ public:
     const char *getAxisName(SDL_GameControllerAxis axis);
     const char *getButtonName(SDL_GameControllerButton button);
 
-private:
 	Input(const RGSSThreadData &rtData);
 	~Input();
 
+private:
 	friend struct SharedStatePrivate;
 
 	InputPrivate *p;


### PR DESCRIPTION
* Some games, such as "Touhou - Wandering Souls" ([rmn.rmarchiv.de download link](https://rmn.rmarchiv.de/games/4732/downloads/Touhou%20-%20Wandering%20Souls%20v1.02.rar)), as well as many Pokémon Essentials games made with Pokémon Essentials versions older than version 19 that use Win32API to get keyboard input, don't call `Input.update` at all. This breaks win32_wrap.rb's input shim because it assumes that the game calls `Input.update` every once in a while. We can't fix it simply by manually calling `Input.update` inside of win32_wrap.rb because this unfortunately breaks most other games that do actually call `Input.update` by themselves. So I propose a compromise: add an `InputInstance` class that serves as a private version of the input state, and use that in win32_wrap.rb instead. This will allow games that don't call `Input.update` to work correctly without breaking games that do call `Input.update`.
* I've added `unless Win32API.method_defined? :mkxp_native_call` at the top of win32_wrap.rb to prevent the script from being run twice (e.g. if kgl2_wrap.rb and win32_wrap.rb are both included in `preloadScripts` in mkxp.json).
* The line `mkxp_native_initialize(@dll, @func, *args)` in win32_wrap.rb may throw a `PHYSFSError` (which is not a subclass of `StandardError` and so will not be caught by the current `begin`/`rescue` block that the line is in). The script should catch these.
* The line `if Win32API_Impl.const_defined?(dll)` in win32_wrap.rb may throw a `NameError` if the name of the DLL happens to contain invalid characters for a Ruby constant. The script should catch these.