### PR TITLE
Automatically upload GitHub Actions artifacts to releases

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -10,6 +10,9 @@ on:
     paths-ignore: ['*.md', '*.json', '*.png']
   workflow_dispatch:
 
+permissions:
+  contents: write # Needed to modify Git tags and GitHub releases in the upload-artifacts job
+
 jobs:
   build-windows:
     name: Windows
@@ -468,3 +471,83 @@ jobs:
         with:
           name: mkxp-z.macos.${{github.event_name == 'pull_request' && format('PR{0}', github.event.number) || github.ref_name}}-${{steps.short-sha.outputs.sha}}
           path: build/Build/Products/Release/Z-universal.app.zip
+
+  upload-artifacts:
+    name: Upload artifacts
+    runs-on: ubuntu-slim
+    needs:
+      - build-windows
+      - build-linux-native
+      - build-linux-cross
+      - build-linux-native-container
+      - build-linux-cross-container
+      - build-macos
+    concurrency:
+      group: upload-artifacts
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: ${{ runner.temp }}/artifacts
+          pattern: mkxp-z.**
+
+      - name: Prepare files
+        run: |
+          cd ${{ runner.temp }}/artifacts
+          for artifact in *
+          do
+            pushd "$artifact"
+            GLOBIGNORE='.:..' zip -r9 "../$artifact.zip" *
+            popd
+            rm -r "$artifact"
+          done
+
+      - name: Upload
+        shell: bash
+        run: |
+          ghcurl () {
+            command="curl --no-progress-meter -f -L -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer ${{ github.token }}' -H 'GitHub-Api-Version: 2026-03-10' ${@@Q}"
+            echo "$command" >&2
+            eval "$command"
+          }
+          release_id=
+          if [ '${{ github.event_name == 'release' }}' = 'true' ]
+          then
+            # Find the release ID for the current release
+            release_id=$(ghcurl ${{ github.api_url }}/repos/${{ github.repository }}/releases/tags/${{ github.ref_name }} | jq -r '.id')
+            do_upload=true
+          elif [ '${{ github.event_name == 'push' && github.ref_name == 'dev' }}' = 'true' ]
+          then
+            # If there already is a release for the nightly tag, delete it
+            curl_output="$(ghcurl ${{ github.api_url }}/repos/${{ github.repository }}/releases/tags/nightly)" || curl_output=
+            if [ -n "$curl_output" ]
+            then
+              ghcurl -X DELETE ${{ github.api_url }}/repos/${{ github.repository }}/releases/$(echo "$curl_output" | jq -r .id)
+            fi
+            # Tag the current commit as nightly
+            git tag -f nightly
+            git push -f origin tag nightly
+            # Create a new release with the nightly tag
+            release_id=$(ghcurl -X POST ${{ github.api_url }}/repos/${{ github.repository }}/releases -d '{
+              "tag_name": "nightly",
+              "target_commitish": "dev",
+              "name": "Nightly build",
+              "body": "This is the latest development build, built from commit [`${{ github.sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}).",
+              "draft": false,
+              "prerelease": true,
+              "generate_release_notes": false
+            }' | jq -r .id)
+            do_upload=true
+          fi
+          if [ -n "$release_id" ]
+          then
+            cd ${{ runner.temp }}/artifacts
+            for artifact in *
+            do
+              ghcurl -X POST -H 'Content-Type: application/octet-stream' https://uploads.github.com/repos/${{ github.repository }}/releases/$release_id/assets?name="$artifact" --data-binary "@$artifact" > /dev/null
+            done
+          fi

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -531,23 +531,23 @@ jobs:
             release_id=$(ghcurl ${{ github.api_url }}/repos/${{ github.repository }}/releases/tags/${{ github.ref_name }} | jq -r '.id')
           elif [ '${{ github.event_name == 'push' && github.ref_name == 'dev' }}' = 'true' ]
           then
-            # Don't update the nightly tag if the current nightly tag is not an ancestor of the current commit
-            if git rev-parse refs/tags/nightly > /dev/null 2>&1 && ! git merge-base --is-ancestor refs/tags/nightly HEAD
+            # Don't update the v9999.9999.9999-nightly tag if the current v9999.9999.9999-nightly tag is not an ancestor of the current commit in order to prevent the v9999.9999.9999-nightly tag from reverting to an earlier commit
+            if git rev-parse refs/tags/v9999.9999.9999-nightly > /dev/null 2>&1 && ! git merge-base --is-ancestor refs/tags/v9999.9999.9999-nightly HEAD
             then
-              echo '::warning::Not uploading artifacts because the nightly tag is not an ancestor of the current commit'
+              echo '::warning::Not uploading artifacts because the v9999.9999.9999-nightly tag is not an ancestor of the current commit'
             else
-              # If there already is a release for the nightly tag, delete it
-              nightly_release_info="$(ghcurl ${{ github.api_url }}/repos/${{ github.repository }}/releases/tags/nightly)" || nightly_release_info=
+              # If there already is a release for the v9999.9999.9999-nightly tag, delete it
+              nightly_release_info="$(ghcurl ${{ github.api_url }}/repos/${{ github.repository }}/releases/tags/v9999.9999.9999-nightly)" || nightly_release_info=
               if [ -n "$nightly_release_info" ]
               then
                 ghcurl -X DELETE ${{ github.api_url }}/repos/${{ github.repository }}/releases/$(echo "$nightly_release_info" | jq -r .id)
               fi
-              # Tag the current commit as nightly
-              git tag -f nightly
-              git push -f origin tag nightly
-              # Create a new release with the nightly tag
+              # Tag the current commit as v9999.9999.9999-nightly
+              git tag -f v9999.9999.9999-nightly
+              git push -f origin tag v9999.9999.9999-nightly
+              # Create a new release with the v9999.9999.9999-nightly tag
               release_id=$(ghcurl -X POST ${{ github.api_url }}/repos/${{ github.repository }}/releases -d '{
-                "tag_name": "nightly",
+                "tag_name": "v9999.9999.9999-nightly",
                 "target_commitish": "${{ github.ref_name }}",
                 "name": "Nightly build",
                 "body": "This is the latest development build, built from commit [`${{ github.sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}).",

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -532,7 +532,7 @@ jobs:
             # Don't update the nightly tag if the current nightly tag is not an ancestor of the current commit
             if git rev-parse refs/tags/nightly > /dev/null 2>&1 && ! git merge-base --is-ancestor refs/tags/nightly HEAD
             then
-              echo '::warning::Not uploading artifacts because the current commit is not an ancestor of the nightly tag'
+              echo '::warning::Not uploading artifacts because the nightly tag is not an ancestor of the current commit'
             else
               # If there already is a release for the nightly tag, delete it
               nightly_release_info="$(ghcurl ${{ github.api_url }}/repos/${{ github.repository }}/releases/tags/nightly)" || nightly_release_info=

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -10,9 +10,6 @@ on:
     paths-ignore: ['*.md', '*.json', '*.png']
   workflow_dispatch:
 
-permissions:
-  contents: write # Needed to modify Git tags and GitHub releases in the upload-artifacts job
-
 jobs:
   build-windows:
     name: Windows
@@ -490,6 +487,8 @@ jobs:
     concurrency:
       group: upload-artifacts
       cancel-in-progress: false
+    permissions:
+      contents: write # Needed to modify Git tags and GitHub releases
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -505,12 +505,12 @@ jobs:
           cd ${{ runner.temp }}/artifacts
           for artifact in *
           do
-            pushd "$artifact"
+            cd "$artifact"
             old_dotglob="$(shopt -p dotglob)"
             shopt -s dotglob
             zip -r9 "../$artifact.zip" *
             eval "$old_dotglob"
-            popd
+            cd ..
             rm -r "$artifact"
           done
 

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -531,6 +531,7 @@ jobs:
           then
             # Don't update the nightly tag if the current nightly tag is not an ancestor of the current commit
             if git rev-parse refs/tags/nightly > /dev/null 2>&1 && ! git merge-base --is-ancestor refs/tags/nightly HEAD
+            then
               echo '::warning::Not uploading artifacts because the current commit is not an ancestor of the nightly tag'
             else
               # If there already is a release for the nightly tag, delete it

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -519,7 +519,6 @@ jobs:
           then
             # Find the release ID for the current release
             release_id=$(ghcurl ${{ github.api_url }}/repos/${{ github.repository }}/releases/tags/${{ github.ref_name }} | jq -r '.id')
-            do_upload=true
           elif [ '${{ github.event_name == 'push' && github.ref_name == 'dev' }}' = 'true' ]
           then
             # If there already is a release for the nightly tag, delete it
@@ -541,7 +540,6 @@ jobs:
               "prerelease": true,
               "generate_release_notes": false
             }' | jq -r .id)
-            do_upload=true
           fi
           if [ -n "$release_id" ]
           then

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches: ['dev', 'autobuild']
     paths-ignore: ['*.md', '*.json', '*.png']
+  release:
+    types: ['published']
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -179,7 +179,8 @@ jobs:
           - arch_mkxpz: armv7-neon
             arch_debian: armhf
             arch_gcc: arm-linux-gnueabihf
-            experimental: false
+            # Theora fails to build for this target currently.
+            experimental: true
           - arch_mkxpz: arm64
             arch_debian: arm64
             arch_gcc: aarch64-linux-gnu
@@ -335,15 +336,19 @@ jobs:
           - arch_mkxpz: armv6
             arch_debian: armhf
             arch_gcc: arm-linux-gnueabihf
-            experimental: false
+            # Pixman fails to compile for 32-bit ARM Debian Trixie targets due to a bug that has been fixed in the latest version of Pixman. We can fix this by updating Pixman.
+            experimental: true
           - arch_mkxpz: armv7
             arch_debian: armhf
             arch_gcc: arm-linux-gnueabihf
-            experimental: false
+            # Pixman fails to compile for 32-bit ARM Debian Trixie targets due to a bug that has been fixed in the latest version of Pixman. We can fix this by updating Pixman.
+            experimental: true
           - arch_mkxpz: armv7-neon
             arch_debian: armhf
             arch_gcc: arm-linux-gnueabihf
-            experimental: false
+            # Pixman fails to compile for 32-bit ARM Debian Trixie targets due to a bug that has been fixed in the latest version of Pixman. We can fix this by updating Pixman.
+            # Also, Theora fails to build for this target currently.
+            experimental: true
           - arch_mkxpz: arm64
             arch_debian: arm64
             arch_gcc: aarch64-linux-gnu

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -500,12 +500,16 @@ jobs:
           pattern: mkxp-z.**
 
       - name: Prepare files
+        shell: bash
         run: |
           cd ${{ runner.temp }}/artifacts
           for artifact in *
           do
             pushd "$artifact"
-            GLOBIGNORE='.:..' zip -r9 "../$artifact.zip" *
+            old_dotglob="$(shopt -p dotglob)"
+            shopt -s dotglob
+            zip -r9 "../$artifact.zip" *
+            eval "$old_dotglob"
             popd
             rm -r "$artifact"
           done

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -529,25 +529,28 @@ jobs:
             release_id=$(ghcurl ${{ github.api_url }}/repos/${{ github.repository }}/releases/tags/${{ github.ref_name }} | jq -r '.id')
           elif [ '${{ github.event_name == 'push' && github.ref_name == 'dev' }}' = 'true' ]
           then
-            # If there already is a release for the nightly tag, delete it
-            curl_output="$(ghcurl ${{ github.api_url }}/repos/${{ github.repository }}/releases/tags/nightly)" || curl_output=
-            if [ -n "$curl_output" ]
-            then
-              ghcurl -X DELETE ${{ github.api_url }}/repos/${{ github.repository }}/releases/$(echo "$curl_output" | jq -r .id)
+            # Don't update the nightly tag if the current nightly tag is not an ancestor of the current commit
+            if ! git rev-parse refs/tags/nightly > /dev/null 2>&1 || git merge-base --is-ancestor refs/tags/nightly HEAD
+              # If there already is a release for the nightly tag, delete it
+              nightly_release_info="$(ghcurl ${{ github.api_url }}/repos/${{ github.repository }}/releases/tags/nightly)" || nightly_release_info=
+              if [ -n "$nightly_release_info" ]
+              then
+                ghcurl -X DELETE ${{ github.api_url }}/repos/${{ github.repository }}/releases/$(echo "$nightly_release_info" | jq -r .id)
+              fi
+              # Tag the current commit as nightly
+              git tag -f nightly
+              git push -f origin tag nightly
+              # Create a new release with the nightly tag
+              release_id=$(ghcurl -X POST ${{ github.api_url }}/repos/${{ github.repository }}/releases -d '{
+                "tag_name": "nightly",
+                "target_commitish": "dev",
+                "name": "Nightly build",
+                "body": "This is the latest development build, built from commit [`${{ github.sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}).",
+                "draft": false,
+                "prerelease": true,
+                "generate_release_notes": false
+              }' | jq -r .id)
             fi
-            # Tag the current commit as nightly
-            git tag -f nightly
-            git push -f origin tag nightly
-            # Create a new release with the nightly tag
-            release_id=$(ghcurl -X POST ${{ github.api_url }}/repos/${{ github.repository }}/releases -d '{
-              "tag_name": "nightly",
-              "target_commitish": "dev",
-              "name": "Nightly build",
-              "body": "This is the latest development build, built from commit [`${{ github.sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}).",
-              "draft": false,
-              "prerelease": true,
-              "generate_release_notes": false
-            }' | jq -r .id)
           fi
           if [ -n "$release_id" ]
           then

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -543,7 +543,7 @@ jobs:
               # Create a new release with the nightly tag
               release_id=$(ghcurl -X POST ${{ github.api_url }}/repos/${{ github.repository }}/releases -d '{
                 "tag_name": "nightly",
-                "target_commitish": "dev",
+                "target_commitish": "${{ github.ref_name }}",
                 "name": "Nightly build",
                 "body": "This is the latest development build, built from commit [`${{ github.sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}).",
                 "draft": false,

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -506,7 +506,7 @@ jobs:
           for artifact in *
           do
             cd "$artifact"
-            old_dotglob="$(shopt -p dotglob)"
+            old_dotglob="$(shopt -p dotglob || :)"
             shopt -s dotglob
             zip -r9 "../$artifact.zip" *
             eval "$old_dotglob"

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -530,7 +530,9 @@ jobs:
           elif [ '${{ github.event_name == 'push' && github.ref_name == 'dev' }}' = 'true' ]
           then
             # Don't update the nightly tag if the current nightly tag is not an ancestor of the current commit
-            if ! git rev-parse refs/tags/nightly > /dev/null 2>&1 || git merge-base --is-ancestor refs/tags/nightly HEAD
+            if git rev-parse refs/tags/nightly > /dev/null 2>&1 && ! git merge-base --is-ancestor refs/tags/nightly HEAD
+              echo '::warning::Not uploading artifacts because the current commit is not an ancestor of the nightly tag'
+            else
               # If there already is a release for the nightly tag, delete it
               nightly_release_info="$(ghcurl ${{ github.api_url }}/repos/${{ github.repository }}/releases/tags/nightly)" || nightly_release_info=
               if [ -n "$nightly_release_info" ]
@@ -551,6 +553,8 @@ jobs:
                 "generate_release_notes": false
               }' | jq -r .id)
             fi
+          else
+            echo '::warning::Not uploading artifacts because artifact uploading is disabled for the ${{ github.event_name }} trigger on ${{ github.ref_name }}'
           fi
           if [ -n "$release_id" ]
           then

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -520,7 +520,7 @@ jobs:
         shell: bash
         run: |
           ghcurl () {
-            command="curl --no-progress-meter -f -L -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer ${{ github.token }}' -H 'GitHub-Api-Version: 2026-03-10' ${@@Q}"
+            command="curl --no-progress-meter --retry 5 -f -L -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer ${{ github.token }}' -H 'GitHub-Api-Version: 2026-03-10' ${@@Q}"
             echo "$command" >&2
             eval "$command"
           }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mkxp-z
 
 <p align="center"><b>
-  <a href="https://github.com/mkxp-z/mkxp-z/actions/workflows/autobuild.yml?query=event%3Apush">Automatic Builds</a>
+  <a href="https://github.com/mkxp-z/mkxp-z/releases">Downloads</a>
   ・
   <a href="https://github.com/mkxp-z/mkxp-z/wiki">Documentation</a>
 </b></p>


### PR DESCRIPTION
This pull request adds a CI job to automatically maintain a release page at https://github.com/mkxp-z/mkxp-z/releases/tag/v9999.9999.9999-nightly containing the CI build artifacts for the latest commit on the dev branch. That way, we can have a single download link for the latest development build artifacts that can be used without having a GitHub account or relying on the third-party https://nightly.link service, and the latest build artifacts will still be available after the 90 day expiry duration. It also results in better user experience, since the UI of GitHub Actions has proven difficult for users to navigate.

Whenever a new release of mkxp-z is published on GitHub, this new job will also upload the build artifacts to that release.

Please note that build artifacts will not be uploaded to releases in either of these two cases unless every build not marked as experimental is successful.

PS: I recommend actually publishing new releases of mkxp-z at some point rather than never updating the version past 2.4.2. Sometimes it's hard to build old versions of mkxp-z, so having old releases permanently available on GitHub will help with detecting regressions. Especially given how hard it is to get users to bisect sometimes.