### PR TITLE
Enable Win32API preload scripts by default

### DIFF
--- a/binding/binding-mri.cpp
+++ b/binding/binding-mri.cpp
@@ -41,6 +41,7 @@
 #include "eventthread.h"
 
 #include <vector>
+#include <unordered_set>
 #include "util/rapidcsv.h"
 
 extern "C" {
@@ -63,6 +64,9 @@ extern "C" {
 #include <SDL_filesystem.h>
 #include <SDL_loadso.h>
 #include <SDL_power.h>
+
+#include "scripts/preload/win32_wrap.rb.xxd"
+#include "scripts/preload/kgl2_wrap.rb.xxd"
 
 extern const char module_rpg1[];
 extern const char module_rpg2[];
@@ -1025,7 +1029,36 @@ static void runRMXPScripts(BacktraceData &btData) {
         
         rb_ary_store(script, 3, rb_utf8_str_new_cstr(decodeBuffer.c_str()));
     }
-    
+
+    /* Execute built-in preload scripts */
+    {
+        int state;
+        std::unordered_set<std::string> disabledBuiltInScripts(conf.disabledBuiltInScripts.begin(), conf.disabledBuiltInScripts.end());
+#ifndef MKXPZ_BUILD_XCODE
+#  define LOAD_BUILTIN_SCRIPT(name) do { \
+            if (disabledBuiltInScripts.count(#name) == 0 || (strcmp(#name, "win32_wrap") == 0 && disabledBuiltInScripts.size() != 0)) { \
+                evalString(rb_utf8_str_new((const char *)___scripts_preload_##name##_rb, ___scripts_preload_##name##_rb_len), rb_utf8_str_new_cstr(#name ".rb"), &state); \
+                if (state) { \
+                    showMsg("Failed to load " #name ".rb"); \
+                } \
+            } \
+        } while (0)
+#else
+#  define LOAD_BUILTIN_SCRIPT(name) do { \
+            if (disabledBuiltInScripts.count(#name) == 0 || (strcmp(#name, "win32_wrap") == 0 && disabledBuiltInScripts.size() != 0)) { \
+                std::string script = mkxp_fs::contentsOfAssetAsString("scripts/preload/" #name, "rb");
+                evalString(rb_utf8_str_new(script.c_str(), script.length(), rb_utf8_str_new_cstr(#name ".rb"), &state); \
+                if (state) { \
+                    showMsg("Failed to load " #name ".rb"); \
+                } \
+            } \
+        } while (0)
+#endif
+        LOAD_BUILTIN_SCRIPT(win32_wrap);
+        LOAD_BUILTIN_SCRIPT(kgl2_wrap);
+#undef LOAD_BUILTIN_SCRIPT
+    }
+
     /* Execute preloaded scripts */
     for (std::vector<std::string>::const_iterator i = conf.preloadScripts.begin();
          i != conf.preloadScripts.end(); ++i)
@@ -1034,7 +1067,7 @@ static void runRMXPScripts(BacktraceData &btData) {
             break;
         runCustomScript(*i);
     }
-    
+
     VALUE exc = rb_gv_get("$!");
     if (exc != Qnil)
         return;

--- a/binding/binding-mri.cpp
+++ b/binding/binding-mri.cpp
@@ -1048,7 +1048,7 @@ static void runRMXPScripts(BacktraceData &btData) {
 #else
 #  define LOAD_BUILTIN_SCRIPT(name) do { \
             if (disabledBuiltInScripts.count(#name) == 0 || (strcmp(#name, "win32_wrap") == 0 && disabledBuiltInScripts.size() != 0)) { \
-                std::string script = mkxp_fs::contentsOfAssetAsString("scripts/preload/" #name, "rb");
+                std::string script = mkxp_fs::contentsOfAssetAsString("scripts/preload/" #name, "rb"); \
                 evalString(rb_utf8_str_new(script.c_str(), script.length()), rb_utf8_str_new_cstr(#name ".rb"), &state); \
                 if (state) { \
                     showMsg("Failed to load " #name ".rb"); \

--- a/binding/binding-mri.cpp
+++ b/binding/binding-mri.cpp
@@ -65,8 +65,10 @@ extern "C" {
 #include <SDL_loadso.h>
 #include <SDL_power.h>
 
+#ifndef MKXPZ_BUILD_XCODE
 #include "scripts/preload/win32_wrap.rb.xxd"
 #include "scripts/preload/kgl2_wrap.rb.xxd"
+#endif
 
 extern const char module_rpg1[];
 extern const char module_rpg2[];

--- a/binding/binding-mri.cpp
+++ b/binding/binding-mri.cpp
@@ -1049,7 +1049,7 @@ static void runRMXPScripts(BacktraceData &btData) {
 #  define LOAD_BUILTIN_SCRIPT(name) do { \
             if (disabledBuiltInScripts.count(#name) == 0 || (strcmp(#name, "win32_wrap") == 0 && disabledBuiltInScripts.size() != 0)) { \
                 std::string script = mkxp_fs::contentsOfAssetAsString("scripts/preload/" #name, "rb");
-                evalString(rb_utf8_str_new(script.c_str(), script.length(), rb_utf8_str_new_cstr(#name ".rb"), &state); \
+                evalString(rb_utf8_str_new(script.c_str(), script.length()), rb_utf8_str_new_cstr(#name ".rb"), &state); \
                 if (state) { \
                     showMsg("Failed to load " #name ".rb"); \
                 } \

--- a/macos/mkxp-z.xcodeproj/project.pbxproj
+++ b/macos/mkxp-z.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		3B10ECED2568E83D00372D13 /* kglShadowH.frag in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3B10ECA82568E7B600372D13 /* kglShadowH.frag */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		3B10ECEE2568E83D00372D13 /* kglShadowV.frag in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3B10ECA92568E7B600372D13 /* kglShadowV.frag */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		3B10ECEF2568E83D00372D13 /* kglSubtract.frag in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3B10ECAA2568E7B600372D13 /* kglSubtract.frag */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		3B10ECEF2568E83D00372D14 /* win32_wrap.rb in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3B10ECAA2568E7B600372D13 /* win32_wrap.rb */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		3B10ECEF2568E83D00372D15 /* kgl2_wrap.rb in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3B10ECAA2568E7B600372D13 /* kgl2_wrap.rb */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		3B10ECF52568E86B00372D13 /* liberation.ttf in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3B10EC842568E78400372D13 /* liberation.ttf */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		3B10EDA62568E95E00372D13 /* eventthread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3B10ED352568E95D00372D13 /* eventthread.cpp */; };
 		3B10EDA72568E95E00372D13 /* rgssad.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3B10ED382568E95D00372D13 /* rgssad.cpp */; };
@@ -777,6 +779,8 @@
 				3B10ECED2568E83D00372D13 /* kglShadowH.frag in CopyFiles */,
 				3B10ECEE2568E83D00372D13 /* kglShadowV.frag in CopyFiles */,
 				3B10ECEF2568E83D00372D13 /* kglSubtract.frag in CopyFiles */,
+				3B10ECEF2568E83D00372D14 /* win32_wrap.rb in CopyFiles */,
+				3B10ECEF2568E83D00372D15 /* kgl2_wrap.rb in CopyFiles */,
 				3F7F41D98CEDE6F418AAB0D2 /* bicubic.frag in CopyFiles */,
 				3D094509A210271690AF48F7 /* xbrz.frag in CopyFiles */,
 			);
@@ -897,6 +901,8 @@
 		3B10ECA82568E7B600372D13 /* kglShadowH.frag */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.glsl; name = kglShadowH.frag; path = ../shader/kglShadowH.frag; sourceTree = "<group>"; };
 		3B10ECA92568E7B600372D13 /* kglShadowV.frag */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.glsl; name = kglShadowV.frag; path = ../shader/kglShadowV.frag; sourceTree = "<group>"; };
 		3B10ECAA2568E7B600372D13 /* kglSubtract.frag */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.glsl; name = kglSubtract.frag; path = ../shader/kglSubtract.frag; sourceTree = "<group>"; };
+		3B10ECAA2568E7B600372D14 /* win32_wrap.rb */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.rb; name = win32_wrap.rb; path = ../scripts/preload/win32_wrap.rb; sourceTree = "<group>"; };
+		3B10ECAA2568E7B600372D15 /* kgl2_wrap.rb */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.rb; name = kgl2_wrap.rb; path = ../scripts/preload/kgl2_wrap.rb; sourceTree = "<group>"; };
 		3B10ED352568E95D00372D13 /* eventthread.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = eventthread.cpp; sourceTree = "<group>"; };
 		3B10ED372568E95D00372D13 /* rgssad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rgssad.h; sourceTree = "<group>"; };
 		3B10ED382568E95D00372D13 /* rgssad.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = rgssad.cpp; sourceTree = "<group>"; };
@@ -1423,6 +1429,15 @@
 			name = Shaders;
 			sourceTree = "<group>";
 		};
+		3B10EC8B2568E79800372D14 /* preload */ = {
+			isa = PBXGroup;
+			children = (
+				3B10ECAA2568E7B600372D14 /* win32_wrap.rb */,
+				3B10ECAA2568E7B600372D15 /* kgl2_wrap.rb */,
+			);
+			name = preload;
+			sourceTree = "<group>";
+		};
 		3B10ED342568E95D00372D13 /* src */ = {
 			isa = PBXGroup;
 			children = (
@@ -1859,6 +1874,7 @@
 				3BDB23E22564546E00C4A63D /* icon.icns */,
 				3BDB2409256470AE00C4A63D /* Player */,
 				3BDB23E12564545F00C4A63D /* Assets */,
+				3BDB23E12564545F00C4A63E /* scripts */,
 				3BA08EA5256641ED00449CFF /* misc */,
 				3BDB22F72564501400C4A63D /* Products */,
 				3BDB23E5256455A400C4A63D /* Frameworks */,
@@ -1888,6 +1904,14 @@
 				3B10EC852568E78400372D13 /* wqymicrohei.ttf */,
 			);
 			name = Assets;
+			sourceTree = "<group>";
+		};
+		3BDB23E12564545F00C4A63E /* scripts */ = {
+			isa = PBXGroup;
+			children = (
+				3B10EC8B2568E79800372D14 /* preload */,
+			);
+			name = scripts;
 			sourceTree = "<group>";
 		};
 		3BDB23E5256455A400C4A63D /* Frameworks */ = {

--- a/meson.build
+++ b/meson.build
@@ -119,6 +119,7 @@ subdir('src')
 subdir('binding')
 subdir('shader')
 subdir('assets')
+subdir('scripts')
 
 global_include_dirs += include_directories('src', 'binding')
 

--- a/mkxp.json
+++ b/mkxp.json
@@ -405,6 +405,13 @@
     //     "/path/to/patch2",
     // ],
 
+    // Built-in scripts to disable.
+    // (default: none)
+    //
+    // "disabledBuiltInScripts": [
+    //     "win32_wrap",
+    //     "kgl2_wrap",
+    // ],
 
     // Use the script's name as filename in warnings and error messages
     // (default: enabled)

--- a/scripts/meson.build
+++ b/scripts/meson.build
@@ -1,0 +1,1 @@
+subdir('preload')

--- a/scripts/preload/kgl2_wrap.rb
+++ b/scripts/preload/kgl2_wrap.rb
@@ -6,6 +6,8 @@
 # to the public domain worldwide.
 # https://creativecommons.org/publicdomain/zero/1.0/
 
+unless Win32API.method_defined? :kgl2_native_call
+
 require_relative 'win32_wrap' unless Win32API.method_defined? :mkxp_native_call
 require 'objspace'
 
@@ -325,4 +327,6 @@ class Win32API
 
 		return kgl2_native_call(*args)
 	end
+end
+
 end

--- a/scripts/preload/meson.build
+++ b/scripts/preload/meson.build
@@ -1,0 +1,13 @@
+embedded_scripts = [
+    'win32_wrap.rb',
+    'kgl2_wrap.rb',
+]
+
+foreach script : embedded_scripts
+    global_dependencies += declare_dependency(sources: custom_target(
+        '@0@.xxd'.format(script),
+        output: '@0@.xxd'.format(script),
+        command: [xxd, '-i', files(script)],
+        capture: true,
+    ))
+endforeach

--- a/scripts/preload/win32_wrap.rb
+++ b/scripts/preload/win32_wrap.rb
@@ -21,6 +21,10 @@
 
 unless Win32API.method_defined? :mkxp_native_call
 
+$win32Graphics = Graphics.dup
+$win32Input = Input.dup
+$win32System = System.dup
+
 module Scancodes
 	SDL = { :UNKNOWN => 0x00,
 		:A => 0x04, :B => 0x05, :C => 0x06, :D => 0x07,
@@ -178,7 +182,7 @@ end
 
 def get_raw_keystates
 	if $win32KeyStates == nil
-		$win32KeyStates = Input.raw_key_states
+		$win32KeyStates = $win32Input.raw_key_states
 	end
 
 	return $win32KeyStates
@@ -191,11 +195,11 @@ def common_keystate(vkey)
 	pressed = false
 
 	if vkey_name == :LBUTTON
-		pressed = Input.press?(Input::MOUSELEFT)
+		pressed = $win32Input.press?($win32Input::MOUSELEFT)
 	elsif vkey_name == :RBUTTON
-		pressed = Input.press?(Input::MOUSERIGHT)
+		pressed = $win32Input.press?($win32Input::MOUSERIGHT)
 	elsif vkey_name == :MBUTTON
-		pressed = Input.press?(Input::MOUSEMIDDLE)
+		pressed = $win32Input.press?($win32Input::MOUSEMIDDLE)
 	elsif vkey_name == :SHIFT
 		pressed = double_state(states, :LSHIFT, :RSHIFT)
 	elsif vkey_name == :MENU
@@ -259,7 +263,7 @@ module Win32API_Impl
 
 				if @index == 4
 					@index = 0
-					Graphics.fullscreen = !Graphics.fullscreen
+					$win32Graphics.fullscreen = !$win32Graphics.fullscreen
 				end
 			end
 		end
@@ -300,13 +304,13 @@ module Win32API_Impl
 					@cursor_count -= 1
 				end
 
-				Graphics.show_cursor = @cursor_count >= 0
+				$win32Graphics.show_cursor = @cursor_count >= 0
 			end
 		end
 
 		class GetCursorPos
 			def call(args)
-				out = [Input.mouse_x, Input.mouse_y].pack('ll')
+				out = [$win32Input.mouse_x, $win32Input.mouse_y].pack('ll')
 				memcpy_string(args[0], out)
 				return 1
 			end
@@ -317,8 +321,8 @@ module Win32API_Impl
 				return 0 if args[0] != 42
 				rect = [0, 0, 640, 480]
 				begin
-					rect[2] = Graphics.width
-					rect[3] = Graphics.height
+					rect[2] = $win32Graphics.width
+					rect[3] = $win32Graphics.height
 				rescue
 				end
 				memcpy_string(args[1], rect.pack('l4'))
@@ -364,7 +368,7 @@ class Win32API
 		func = kappatalize(func)
 
 		begin
-			if !System.is_windows? or !NATIVE_ON_WINDOWS
+			if !$win32System.is_windows? or !NATIVE_ON_WINDOWS
 				if Win32API_Impl.const_defined?(dll)
 					dll_impl = Win32API_Impl.const_get(dll)
 					if dll_impl.const_defined?(func)
@@ -394,13 +398,13 @@ class Win32API
 
 		if @mkxp_native_available
 			if LOG_NATIVE
-				System.puts("[Win32API] [#{@dll}:#{@func}] #{args.to_s}")
+				$win32System.puts("[Win32API] [#{@dll}:#{@func}] #{args.to_s}")
 			end
 			return mkxp_native_call(*args)
 		end
 
 		if TOLERATE_ERRORS
-			System.puts("[Win32API] [#{@dll}:#{@func}] #{args.to_s}") if !@called
+			$win32System.puts("[Win32API] [#{@dll}:#{@func}] #{args.to_s}") if !@called
 			@called = true
 			return 0
 		else

--- a/scripts/preload/win32_wrap.rb
+++ b/scripts/preload/win32_wrap.rb
@@ -15,6 +15,7 @@
 # To tweak behavior, you can set the following Win32API class constants in an
 # earlier preload script (these are usually only helpful for debugging):
 #
+# NATIVE_ON_WINDOWS=false
 # TOLERATE_ERRORS=false
 # LOG_NATIVE=true
 
@@ -349,6 +350,7 @@ def kappatalize(s)
 end
 
 class Win32API
+	NATIVE_ON_WINDOWS = true unless const_defined?("NATIVE_ON_WINDOWS")
 	TOLERATE_ERRORS = true unless const_defined?("TOLERATE_ERRORS")
 	LOG_NATIVE = false unless const_defined?("LOG_NATIVE")
 
@@ -361,6 +363,19 @@ class Win32API
 		dll = kappatalize(dll.chomp(".dll"))
 		func = kappatalize(func)
 
+		begin
+			if !System.is_windows? or !NATIVE_ON_WINDOWS
+				if Win32API_Impl.const_defined?(dll)
+					dll_impl = Win32API_Impl.const_get(dll)
+					if dll_impl.const_defined?(func)
+						@mkxp_wrap_impl = dll_impl.const_get(func).new
+						return
+					end
+				end
+			end
+		rescue Exception
+		end
+
 		@mkxp_native_available = false
 		begin
 			mkxp_native_initialize(@dll, @func, *args)
@@ -369,16 +384,6 @@ class Win32API
 		rescue Exception
 		end
 
-		begin
-			if Win32API_Impl.const_defined?(dll)
-				dll_impl = Win32API_Impl.const_get(dll)
-				if dll_impl.const_defined?(func)
-					@mkxp_wrap_impl = dll_impl.const_get(func).new
-					return
-				end
-			end
-		rescue Exception
-		end
 	end
 
 	alias_method :mkxp_native_call, :call

--- a/scripts/preload/win32_wrap.rb
+++ b/scripts/preload/win32_wrap.rb
@@ -15,9 +15,10 @@
 # To tweak behavior, you can set the following Win32API class constants in an
 # earlier preload script (these are usually only helpful for debugging):
 #
-# NATIVE_ON_WINDOWS=false
 # TOLERATE_ERRORS=false
 # LOG_NATIVE=true
+
+unless Win32API.method_defined? :mkxp_native_call
 
 module Scancodes
 	SDL = { :UNKNOWN => 0x00,
@@ -348,7 +349,6 @@ def kappatalize(s)
 end
 
 class Win32API
-	NATIVE_ON_WINDOWS = true unless const_defined?("NATIVE_ON_WINDOWS")
 	TOLERATE_ERRORS = true unless const_defined?("TOLERATE_ERRORS")
 	LOG_NATIVE = false unless const_defined?("LOG_NATIVE")
 
@@ -361,7 +361,15 @@ class Win32API
 		dll = kappatalize(dll.chomp(".dll"))
 		func = kappatalize(func)
 
-		if !System.is_windows? or !NATIVE_ON_WINDOWS
+		@mkxp_native_available = false
+		begin
+			mkxp_native_initialize(@dll, @func, *args)
+			@mkxp_native_available = true
+			return
+		rescue Exception
+		end
+
+		begin
 			if Win32API_Impl.const_defined?(dll)
 				dll_impl = Win32API_Impl.const_get(dll)
 				if dll_impl.const_defined?(func)
@@ -369,16 +377,8 @@ class Win32API
 					return
 				end
 			end
+		rescue Exception
 		end
-
-		@mkxp_native_available = false
-		begin
-			mkxp_native_initialize(@dll, @func, *args)
-			@mkxp_native_available = true
-			return
-		rescue
-		end
-
 	end
 
 	alias_method :mkxp_native_call, :call
@@ -402,4 +402,6 @@ class Win32API
 			raise RuntimeError, "[Win32API] [#{@dll}:#{@func}] #{args.to_s}"
 		end
 	end
+end
+
 end

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -190,6 +190,7 @@ void Config::read(int argc, char *argv[]) {
         {"postloadScript", json::array({})},
         {"RTP", json::array({})},
         {"patches", json::array({})},
+        {"disabledBuiltInScripts", json::array({})},
         {"fontSub", json::array({})},
         {"fontScale", 0.0f},
         {"fontKerning", true},
@@ -325,6 +326,7 @@ try { exp } catch (...) {}
     fillStringVec(opts["postloadScript"], postloadScripts);
     fillStringVec(opts["RTP"], rtps);
     fillStringVec(opts["patches"], patches);
+    fillStringVec(opts["disabledBuiltInScripts"], disabledBuiltInScripts);
     fillStringVec(opts["fontSub"], fontSubs);
     for (std::string & fontSub : fontSubs)
         std::transform(fontSub.begin(), fontSub.end(), fontSub.begin(),

--- a/src/config.h
+++ b/src/config.h
@@ -116,6 +116,7 @@ struct Config {
     std::vector<std::string> postloadScripts;
     std::vector<std::string> rtps;
     std::vector<std::string> patches;
+    std::vector<std::string> disabledBuiltInScripts;
     
     std::vector<std::string> fontSubs;
     float fontScale;


### PR DESCRIPTION
This pull request embeds win32_wrap.rb and kgl2_wrap.rb into the binaries and enables them by default. I see no reason why someone would not want to enable these at this point.