### PR TITLE
Fix breakage of `WindowVX` contents offset caused by mkxp-z/mkxp-z#333

### DIFF
--- a/src/display/windowvx.cpp
+++ b/src/display/windowvx.cpp
@@ -857,7 +857,7 @@ struct WindowVXPrivate
 					glState.scissorBox.setIntersect(clip);
 
 				Vec2i contTrans = pad.pos();
-				contTrans -= contentsOff;
+				contTrans -= realContentsOff;
 				shader.setTranslation(contTrans);
 
 				TEX::setSmooth(false); // XXX


### PR DESCRIPTION
I think this line might be a typo, since the equivalent line in src/display/window.cpp uses `realContentsOffset` and not `contentsOffset`.