### PR TITLE
Add fallback paths for RTPs

### DIFF
--- a/mkxp.json
+++ b/mkxp.json
@@ -387,6 +387,18 @@
     // (multiple allowed). You can use folders, RGSS archives, and any archive
     // formats supported by PhysicsFS; see the compatibility list at:
     // https://www.icculus.org/physfs/docs/html/
+    // If a relative path is provided, it's first searched for in the game
+    // directory, and then if it isn't there it's searched for in the RTP
+    // subdirectory of the preferences directory, located at
+    // "%appdata%/mkxp-z/RTP" on Windows,
+    // "~/Library/Application Support/mkxp-z/RTP" on macOS and
+    // "~/.local/share/mkxp-z/RTP" on Linux. On Windows only, if a
+    // relative path is provided and the RTP isn't found in the game directory
+    // or the RTP subdirectory of the preferences directory, the Windows
+    // registry will be searched for installation paths of RTPs installed by the
+    // official RTP installers. RTPs specified in Game.ini will also be searched
+    // in this way, however the game directory will not be searched for RTPs
+    // specified in Game.ini.
     // (default: none)
     //
     // "RTP": [

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -408,6 +408,18 @@ void Config::readGameINI() {
         {
             GUARD(game.title = ic.getStringProperty("Game", "Title"););
             GUARD(game.scripts = ic.getStringProperty("Game", "Scripts"););
+#define LOAD_INI_RTP(property) do { \
+                std::string str; \
+                GUARD(str = ic.getStringProperty("Game", #property);); \
+                if (!str.empty()) { \
+                    iniRtps.push_back(str); \
+                } \
+            } while (0)
+            LOAD_INI_RTP(RTP);
+            LOAD_INI_RTP(RTP1);
+            LOAD_INI_RTP(RTP2);
+            LOAD_INI_RTP(RTP3);
+#undef LOAD_INI_RTP
             
             strReplace(game.scripts, '\\', '/');
             

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -419,6 +419,12 @@ void Config::readGameINI() {
             LOAD_INI_RTP(RTP1);
             LOAD_INI_RTP(RTP2);
             LOAD_INI_RTP(RTP3);
+            LOAD_INI_RTP(RTP4);
+            LOAD_INI_RTP(RTP5);
+            LOAD_INI_RTP(RTP6);
+            LOAD_INI_RTP(RTP7);
+            LOAD_INI_RTP(RTP8);
+            LOAD_INI_RTP(RTP9);
 #undef LOAD_INI_RTP
             
             strReplace(game.scripts, '\\', '/');

--- a/src/config.h
+++ b/src/config.h
@@ -115,6 +115,7 @@ struct Config {
     std::vector<std::string> preloadScripts;
     std::vector<std::string> postloadScripts;
     std::vector<std::string> rtps;
+    std::vector<std::string> iniRtps;
     std::vector<std::string> patches;
     
     std::vector<std::string> fontSubs;

--- a/src/sharedstate.cpp
+++ b/src/sharedstate.cpp
@@ -106,7 +106,7 @@ static std::string resolveRtpPath(
 		/* Check in the Windows registry */
 		std::vector<char> buffer;
 		DWORD size;
-		error = RegGetValueA(
+		LSTATUS error = RegGetValueA(
 			hkey,
 			nullptr,
 			rtp.c_str(),
@@ -136,7 +136,7 @@ static std::string resolveRtpPath(
 		}
 		if (!buffer.empty()) {
 			buffer.push_back(0);
-			rtp = fs::path(buffer.data()) / rtp;
+			return buffer.data();
 		}
 #endif // _WIN32
 
@@ -252,7 +252,7 @@ struct SharedStatePrivate
 				default:
 					assert(!"unreachable");
 			}
-			LSTATUS error = RegOpenKeyExA(
+			RegOpenKeyExA(
 				HKEY_LOCAL_MACHINE,
 				rtpKey,
 				0,

--- a/src/sharedstate.cpp
+++ b/src/sharedstate.cpp
@@ -120,7 +120,7 @@ static std::string resolveRtpPath(
 				&size
 			);
 			if (error != ERROR_SUCCESS) {
-				buffer.clear();
+				size = 0;
 			} else {
 				do {
 					buffer.resize(size);
@@ -135,10 +135,10 @@ static std::string resolveRtpPath(
 					);
 				} while (error == ERROR_MORE_DATA);
 				if (error != ERROR_SUCCESS) {
-					buffer.clear();
+					size = 0;
 				}
 			}
-			if (!buffer.empty()) {
+			if (size != 0) {
 				buffer.resize(size);
 				buffer.pop_back();
 				buffer.pop_back();

--- a/src/sharedstate.cpp
+++ b/src/sharedstate.cpp
@@ -86,7 +86,7 @@ static std::string resolveRtpPath(
 #endif // _WIN32
 )
 {
-	std::string rtp = rtpRaw;
+	std::string rtp(rtpRaw);
 	for (char &c : rtp) {
 		if (c == '\\') {
 			c = '/';
@@ -106,14 +106,14 @@ static std::string resolveRtpPath(
 #ifdef _WIN32
 		/* Check in the Windows registry */
 		if (hkey != HKEY_LOCAL_MACHINE) {
-			std::string rtpUtf16Le(Encoding::convertStringToUtf16Le(rtp, "UTF-8"));
-			rtpUtf16Le.push_back(0);
+			std::string rtpRawUtf16Le(Encoding::convertStringToUtf16Le(rtpRaw, "UTF-8"));
+			rtpRawUtf16Le.push_back(0);
 			std::vector<char> buffer;
 			DWORD size;
 			LSTATUS error = RegGetValueW(
 				hkey,
 				nullptr,
-				(const wchar_t *)rtpUtf16Le.data(),
+				(const wchar_t *)rtpRawUtf16Le.data(),
 				RRF_RT_REG_SZ,
 				nullptr,
 				nullptr,
@@ -127,7 +127,7 @@ static std::string resolveRtpPath(
 					error = RegGetValueW(
 						hkey,
 						nullptr,
-						(const wchar_t *)rtpUtf16Le.data(),
+						(const wchar_t *)rtpRawUtf16Le.data(),
 						RRF_RT_REG_SZ,
 						nullptr,
 						buffer.data(),

--- a/src/sharedstate.cpp
+++ b/src/sharedstate.cpp
@@ -98,45 +98,47 @@ static std::string resolveRtpPath(
 		}
 
 		/* Search for the RTP in the pref path */
-		if (fs::exists(rtpDir / rtp)) {
+		if (!rtpDir.empty() && fs::exists(rtpDir / rtp)) {
 			return rtpDir / rtp;
 		}
 
 #ifdef _WIN32
 		/* Check in the Windows registry */
-		std::vector<char> buffer;
-		DWORD size;
-		LSTATUS error = RegGetValueA(
-			hkey,
-			nullptr,
-			rtp.c_str(),
-			RRF_RT_REG_SZ,
-			nullptr,
-			nullptr,
-			&size
-		);
-		if (error != ERROR_SUCCESS) {
-			buffer.clear();
-		} else {
-			do {
-				buffer.resize(size);
-				error = RegGetValueA(
-					hkey,
-					nullptr,
-					rtp.c_str(),
-					RRF_RT_REG_SZ,
-					nullptr,
-					buffer.data(),
-					&size
-				);
-			} while (error == ERROR_MORE_DATA);
+		if (hkey != HKEY_LOCAL_MACHINE) {
+			std::vector<char> buffer;
+			DWORD size;
+			LSTATUS error = RegGetValueA(
+				hkey,
+				nullptr,
+				rtp.c_str(),
+				RRF_RT_REG_SZ,
+				nullptr,
+				nullptr,
+				&size
+			);
 			if (error != ERROR_SUCCESS) {
 				buffer.clear();
+			} else {
+				do {
+					buffer.resize(size);
+					error = RegGetValueA(
+						hkey,
+						nullptr,
+						rtp.c_str(),
+						RRF_RT_REG_SZ,
+						nullptr,
+						buffer.data(),
+						&size
+					);
+				} while (error == ERROR_MORE_DATA);
+				if (error != ERROR_SUCCESS) {
+					buffer.clear();
+				}
 			}
-		}
-		if (!buffer.empty()) {
-			buffer.push_back(0);
-			return buffer.data();
+			if (!buffer.empty()) {
+				buffer.push_back(0);
+				return buffer.data();
+			}
 		}
 #endif // _WIN32
 

--- a/src/sharedstate.cpp
+++ b/src/sharedstate.cpp
@@ -106,14 +106,14 @@ static std::string resolveRtpPath(
 #ifdef _WIN32
 		/* Check in the Windows registry */
 		if (hkey != HKEY_LOCAL_MACHINE) {
-			std::string rtpRawUtf16Le(Encoding::convertStringToUtf16Le(rtpRaw, "UTF-8"));
-			rtpRawUtf16Le.push_back(0);
+			std::string rtpRawUtf16(Encoding::convertStringToUtf16(rtpRaw, "UTF-8"));
+			rtpRawUtf16.push_back(0);
 			std::vector<char> buffer;
 			DWORD size;
 			LSTATUS error = RegGetValueW(
 				hkey,
 				nullptr,
-				(const wchar_t *)rtpRawUtf16Le.data(),
+				(LPCWSTR)rtpRawUtf16.data(),
 				RRF_RT_REG_SZ,
 				nullptr,
 				nullptr,
@@ -127,7 +127,7 @@ static std::string resolveRtpPath(
 					error = RegGetValueW(
 						hkey,
 						nullptr,
-						(const wchar_t *)rtpRawUtf16Le.data(),
+						(LPCWSTR)rtpRawUtf16.data(),
 						RRF_RT_REG_SZ,
 						nullptr,
 						buffer.data(),
@@ -141,7 +141,7 @@ static std::string resolveRtpPath(
 			if (!buffer.empty()) {
 				buffer.pop_back();
 				buffer.pop_back();
-				return Encoding::convertString(std::string(std::make_move_iterator(buffer.begin()), std::make_move_iterator(buffer.end())), "UTF-16LE");
+				return Encoding::convertString(std::string(std::make_move_iterator(buffer.begin()), std::make_move_iterator(buffer.end())), "UTF-16");
 			}
 		}
 #endif // _WIN32

--- a/src/sharedstate.cpp
+++ b/src/sharedstate.cpp
@@ -36,6 +36,7 @@
 #include "quad.h"
 #include "binding.h"
 #include "exception.h"
+#include "encoding.h"
 #include "sharedmidistate.h"
 
 #include <unistd.h>
@@ -105,12 +106,14 @@ static std::string resolveRtpPath(
 #ifdef _WIN32
 		/* Check in the Windows registry */
 		if (hkey != HKEY_LOCAL_MACHINE) {
+			std::string rtpUtf16Le(Encoding::convertStringToUtf16Le(rtp, "UTF-8"));
+			rtpUtf16Le.push_back(0);
 			std::vector<char> buffer;
 			DWORD size;
-			LSTATUS error = RegGetValueA(
+			LSTATUS error = RegGetValueW(
 				hkey,
 				nullptr,
-				rtp.c_str(),
+				(wchar_t *)rtpUtf16Le.data(),
 				RRF_RT_REG_SZ,
 				nullptr,
 				nullptr,
@@ -121,10 +124,10 @@ static std::string resolveRtpPath(
 			} else {
 				do {
 					buffer.resize(size);
-					error = RegGetValueA(
+					error = RegGetValueW(
 						hkey,
 						nullptr,
-						rtp.c_str(),
+						(wchar_t *)rtpUtf16Le.data(),
 						RRF_RT_REG_SZ,
 						nullptr,
 						buffer.data(),
@@ -136,8 +139,9 @@ static std::string resolveRtpPath(
 				}
 			}
 			if (!buffer.empty()) {
-				buffer.push_back(0);
-				return buffer.data();
+				buffer.pop_back();
+				buffer.pop_back();
+				return Encoding::convertString(std::string(std::make_move_iterator(buffer.begin()), std::make_move_iterator(buffer.end())), "UTF-16LE");
 			}
 		}
 #endif // _WIN32

--- a/src/sharedstate.cpp
+++ b/src/sharedstate.cpp
@@ -139,6 +139,7 @@ static std::string resolveRtpPath(
 				}
 			}
 			if (!buffer.empty()) {
+				buffer.resize(size);
 				buffer.pop_back();
 				buffer.pop_back();
 				return Encoding::convertString(std::string(std::make_move_iterator(buffer.begin()), std::make_move_iterator(buffer.end())), "UTF-16");

--- a/src/sharedstate.cpp
+++ b/src/sharedstate.cpp
@@ -43,6 +43,20 @@
 #include <string>
 #include <chrono>
 
+#include <SDL_filesystem.h>
+
+#ifdef MKXPZ_EXP_FS
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#include "ghc/filesystem.hpp"
+namespace fs = ghc::filesystem;
+#endif
+
+#ifdef _WIN32
+#  include <winreg.h>
+#endif // _WIN32
+
 SharedState *SharedState::instance = 0;
 int SharedState::rgssVersion = 0;
 static GlobalIBO *_globalIBO = 0;
@@ -58,6 +72,80 @@ static const char *gameArchExt()
 
 	assert(!"unreachable");
 	return 0;
+}
+
+static std::string resolveRtpPath(
+	const std::string &rtpRaw,
+	bool allowCurrentDir,
+	const fs::path &rtpDir,
+#ifdef _WIN32
+	HKEY hkey
+#else
+	const void *_unused
+#endif // _WIN32
+)
+{
+	std::string rtp = rtpRaw;
+	for (char &c : rtp) {
+		if (c == '\\') {
+			c = '/';
+		}
+	}
+
+	if (fs::path(rtp).is_relative()) {
+		if (allowCurrentDir && fs::exists(rtp)) {
+			return rtp;
+		}
+
+		/* Search for the RTP in the pref path */
+		if (fs::exists(rtpDir / rtp)) {
+			return rtpDir / rtp;
+		}
+
+#ifdef _WIN32
+		/* Check in the Windows registry */
+		std::vector<char> buffer;
+		DWORD size;
+		error = RegGetValueA(
+			hkey,
+			nullptr,
+			rtp.c_str(),
+			RRF_RT_REG_SZ,
+			nullptr,
+			nullptr,
+			&size
+		);
+		if (error != ERROR_SUCCESS) {
+			buffer.clear();
+		} else {
+			do {
+				buffer.resize(size);
+				error = RegGetValueA(
+					hkey,
+					nullptr,
+					rtp.c_str(),
+					RRF_RT_REG_SZ,
+					nullptr,
+					buffer.data(),
+					&size
+				);
+			} while (error == ERROR_MORE_DATA);
+			if (error != ERROR_SUCCESS) {
+				buffer.clear();
+			}
+		}
+		if (!buffer.empty()) {
+			buffer.push_back(0);
+			rtp = fs::path(buffer.data()) / rtp;
+		}
+#endif // _WIN32
+
+		if (!allowCurrentDir) {
+			throw Exception(Exception::PHYSFSError, "Failed to resolve %s RTP", rtp.c_str());
+		}
+	}
+
+	return rtp;
 }
 
 struct SharedStatePrivate
@@ -141,8 +229,58 @@ struct SharedStatePrivate
 
 		fileSystem.addPath(".");
 
-		for (size_t i = 0; i < config.rtps.size(); ++i)
-			fileSystem.addPath(config.rtps[i].c_str());
+		{
+			char *prefDir = SDL_GetPrefPath("mkxp-z", "mkxp-z");
+			fs::path rtpDir;
+			if (prefDir != nullptr) {
+				rtpDir = std::string(prefDir) + "RTP";
+				fs::create_directory(rtpDir);
+			}
+#ifdef _WIN32
+			HKEY hkey = HKEY_LOCAL_MACHINE;
+			const char *rtpKey;
+			switch (rgssVer) {
+				case 1:
+					rtpKey = "Software\\Enterbrain\\RGSS\\RTP";
+					break;
+				case 2:
+					rtpKey = "Software\\Enterbrain\\RGSS2\\RTP";
+					break;
+				case 3:
+					rtpKey = "Software\\Enterbrain\\RGSS3\\RTP";
+					break;
+				default:
+					assert(!"unreachable");
+			}
+			LSTATUS error = RegOpenKeyExA(
+				HKEY_LOCAL_MACHINE,
+				rtpKey,
+				0,
+				KEY_WOW64_32KEY,
+				&hkey
+			);
+#else
+			const void *hkey = nullptr;
+#endif // _WIN32
+			for (const std::string &rtpRaw : config.rtps) {
+				fileSystem.addPath(resolveRtpPath(rtpRaw, true, rtpDir, hkey).c_str());
+			}
+			for (const std::string &rtpRaw : config.iniRtps) {
+				try {
+					fileSystem.addPath(resolveRtpPath(rtpRaw, false, rtpDir, hkey).c_str());
+				} catch (const Exception &e) {
+					Debug() << "Error mounting RTP" << rtpRaw << ":" << e.msg;
+				}
+			}
+#ifdef _WIN32
+			if (hkey != HKEY_LOCAL_MACHINE) {
+				RegCloseKey(hkey);
+			}
+#endif // _WIN32
+			if (prefDir != nullptr) {
+				SDL_free(prefDir);
+			}
+		}
 
 		if (config.pathCache)
 			fileSystem.createPathCache();

--- a/src/sharedstate.cpp
+++ b/src/sharedstate.cpp
@@ -105,7 +105,7 @@ static std::string resolveRtpPath(
 
 #ifdef _WIN32
 		/* Check in the Windows registry */
-		if (hkey != HKEY_LOCAL_MACHINE) {
+		if (hkey != nullptr) {
 			std::string rtpRawUtf16(Encoding::convertStringToUtf16(rtpRaw, "UTF-8"));
 			rtpRawUtf16.push_back(0);
 			std::vector<char> buffer;
@@ -243,7 +243,7 @@ struct SharedStatePrivate
 				fs::create_directory(rtpDir);
 			}
 #ifdef _WIN32
-			HKEY hkey = HKEY_LOCAL_MACHINE;
+			HKEY hkey = nullptr;
 			const char *rtpKey;
 			switch (rgssVer) {
 				case 1:
@@ -279,7 +279,7 @@ struct SharedStatePrivate
 				}
 			}
 #ifdef _WIN32
-			if (hkey != HKEY_LOCAL_MACHINE) {
+			if (hkey != nullptr) {
 				RegCloseKey(hkey);
 			}
 #endif // _WIN32

--- a/src/sharedstate.cpp
+++ b/src/sharedstate.cpp
@@ -44,6 +44,7 @@
 #include <string>
 #include <chrono>
 
+#include <SDL_endian.h>
 #include <SDL_filesystem.h>
 
 #ifdef MKXPZ_EXP_FS
@@ -57,6 +58,12 @@ namespace fs = ghc::filesystem;
 #ifdef _WIN32
 #  include <winreg.h>
 #endif // _WIN32
+
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+#  define MKXPZ_ENCODING_UTF16_NATIVE "UTF-16BE"
+#else
+#  define MKXPZ_ENCODING_UTF16_NATIVE "UTF-16LE"
+#endif
 
 SharedState *SharedState::instance = 0;
 int SharedState::rgssVersion = 0;
@@ -106,7 +113,7 @@ static std::string resolveRtpPath(
 #ifdef _WIN32
 		/* Check in the Windows registry */
 		if (hkey != nullptr) {
-			std::string rtpRawUtf16(Encoding::convertStringToUtf16(rtpRaw, "UTF-8"));
+			std::string rtpRawUtf16(Encoding::convertString(rtpRaw, "UTF-8", MKXPZ_ENCODING_UTF16_NATIVE));
 			rtpRawUtf16.push_back(0);
 			std::vector<char> buffer;
 			DWORD size;
@@ -142,7 +149,7 @@ static std::string resolveRtpPath(
 				buffer.resize(size);
 				buffer.pop_back();
 				buffer.pop_back();
-				return Encoding::convertString(std::string(std::make_move_iterator(buffer.begin()), std::make_move_iterator(buffer.end())), "UTF-16");
+				return Encoding::convertString(std::string(std::make_move_iterator(buffer.begin()), std::make_move_iterator(buffer.end())), MKXPZ_ENCODING_UTF16_NATIVE);
 			}
 		}
 #endif // _WIN32

--- a/src/sharedstate.cpp
+++ b/src/sharedstate.cpp
@@ -258,7 +258,7 @@ struct SharedStatePrivate
 				HKEY_LOCAL_MACHINE,
 				rtpKey,
 				0,
-				KEY_WOW64_32KEY,
+				KEY_QUERY_VALUE | KEY_WOW64_32KEY,
 				&hkey
 			);
 #else

--- a/src/sharedstate.cpp
+++ b/src/sharedstate.cpp
@@ -113,7 +113,7 @@ static std::string resolveRtpPath(
 			LSTATUS error = RegGetValueW(
 				hkey,
 				nullptr,
-				(wchar_t *)rtpUtf16Le.data(),
+				(const wchar_t *)rtpUtf16Le.data(),
 				RRF_RT_REG_SZ,
 				nullptr,
 				nullptr,
@@ -127,7 +127,7 @@ static std::string resolveRtpPath(
 					error = RegGetValueW(
 						hkey,
 						nullptr,
-						(wchar_t *)rtpUtf16Le.data(),
+						(const wchar_t *)rtpUtf16Le.data(),
 						RRF_RT_REG_SZ,
 						nullptr,
 						buffer.data(),

--- a/src/sharedstate.cpp
+++ b/src/sharedstate.cpp
@@ -236,7 +236,7 @@ struct SharedStatePrivate
 		fileSystem.addPath(".");
 
 		{
-			char *prefDir = SDL_GetPrefPath("mkxp-z", "mkxp-z");
+			char *prefDir = SDL_GetPrefPath(nullptr, "mkxp-z");
 			fs::path rtpDir;
 			if (prefDir != nullptr) {
 				rtpDir = std::string(prefDir) + "RTP";

--- a/src/util/encoding.h
+++ b/src/util/encoding.h
@@ -18,7 +18,7 @@
 
 namespace Encoding {
 
-static std::string getCharset(std::string &str) {
+static std::string getCharset(const std::string &str) {
     uchardet_t ud = uchardet_new();
     uchardet_handle_data(ud, str.c_str(), str.length());
     uchardet_data_end(ud);
@@ -31,7 +31,7 @@ static std::string getCharset(std::string &str) {
     return ret;
 }
 
-static std::string convertString(std::string &str, const char *charset) {
+static std::string convertString(const std::string &str, const char *charset) {
     // Conversion doesn't need to happen if it's already UTF-8
     if (!strcmp(charset, "UTF-8") || !strcmp(charset, "ASCII")) {
         return std::string(str);
@@ -61,7 +61,32 @@ static std::string convertString(std::string &str, const char *charset) {
     return buf;
 }
 
-static std::string convertString(std::string &str) {
+static std::string convertStringToUtf16Le(const std::string &str, const char *charset) {
+    iconv_t cd = iconv_open("UTF-16LE", charset);
+    
+    size_t inLen = str.size();
+    size_t outLen = inLen * 4;
+    std::string buf(outLen, '\0');
+    char *inPtr = const_cast<char*>(str.c_str());
+    char *outPtr = const_cast<char*>(buf.c_str());
+    
+    errno = 0;
+    size_t result = iconv(cd, &inPtr, &inLen, &outPtr, &outLen);
+    
+    iconv_close(cd);
+    
+    if (result != (size_t)-1 && errno == 0)
+    {
+        buf.resize(buf.size()-outLen);
+    }
+    else {
+        throw Exception(Exception::MKXPError, "Unable to convert string (Guessed encoding: %s)", charset);
+    }
+    
+    return buf;
+}
+
+static std::string convertString(const std::string &str) {
     return convertString(str, getCharset(str).c_str());
 }
 }

--- a/src/util/encoding.h
+++ b/src/util/encoding.h
@@ -31,38 +31,13 @@ static std::string getCharset(const std::string &str) {
     return ret;
 }
 
-static std::string convertString(const std::string &str, const char *charset) {
+static std::string convertString(const std::string &str, const char *charset, const char *destCharset = "UTF-8") {
     // Conversion doesn't need to happen if it's already UTF-8
-    if (!strcmp(charset, "UTF-8") || !strcmp(charset, "ASCII")) {
+    if (!strcmp(destCharset, "UTF-8") && (!strcmp(charset, "UTF-8") || !strcmp(charset, "ASCII"))) {
         return std::string(str);
     }
     
-    iconv_t cd = iconv_open("UTF-8", charset);
-    
-    size_t inLen = str.size();
-    size_t outLen = inLen * 4;
-    std::string buf(outLen, '\0');
-    char *inPtr = const_cast<char*>(str.c_str());
-    char *outPtr = const_cast<char*>(buf.c_str());
-    
-    errno = 0;
-    size_t result = iconv(cd, &inPtr, &inLen, &outPtr, &outLen);
-    
-    iconv_close(cd);
-    
-    if (result != (size_t)-1 && errno == 0)
-    {
-        buf.resize(buf.size()-outLen);
-    }
-    else {
-        throw Exception(Exception::MKXPError, "Unable to convert string (Guessed encoding: %s)", charset);
-    }
-    
-    return buf;
-}
-
-static std::string convertStringToUtf16(const std::string &str, const char *charset) {
-    iconv_t cd = iconv_open("UTF-16", charset);
+    iconv_t cd = iconv_open(destCharset, charset);
     
     size_t inLen = str.size();
     size_t outLen = inLen * 4;

--- a/src/util/encoding.h
+++ b/src/util/encoding.h
@@ -61,8 +61,8 @@ static std::string convertString(const std::string &str, const char *charset) {
     return buf;
 }
 
-static std::string convertStringToUtf16Le(const std::string &str, const char *charset) {
-    iconv_t cd = iconv_open("UTF-16LE", charset);
+static std::string convertStringToUtf16(const std::string &str, const char *charset) {
+    iconv_t cd = iconv_open("UTF-16", charset);
     
     size_t inLen = str.size();
     size_t outLen = inLen * 4;


### PR DESCRIPTION
If a Run Time Package specified in mkxp.json can't be found in the game directory, mkxp-z will now look in \<SDL preference directory for mkxp-z\>/RTP as a fallback. On Windows, if it can't be found in the fallback directory either, it will also check the Windows registry for RTPs installed using the official RTP installer executables.

This pull request also enables searching for RTPs specified in Game.ini so that if you put the three official RTPs into the fallback directory (or on Windows, install the RTPs anywhere using the official installers), games that require the official RTPs will be playable without having to manually specify RTPs in mkxp.json. For backwards compatibility, if an RTP specified in Game.ini can't be found, there won't be an error; instead, an error message will be printed to standard error but the game loading will continue normally.

* Closes #249 