### PR TITLE
Support absolute paths for DLL loading in win32_wrap.rb

### DIFF
--- a/scripts/preload/win32_wrap.rb
+++ b/scripts/preload/win32_wrap.rb
@@ -310,8 +310,6 @@ module Win32API_Impl
 			end
 		end
 
-
-		# Example: GetClientRect.call (use same safe_memcpy_string)
 		class GetClientRect
 			def call(args)
 				return 0 if args[0] != 42
@@ -325,7 +323,6 @@ module Win32API_Impl
 				return 1
 			end
 		end
-
 
 		class ScreenToClient
 			def call(args)
@@ -371,8 +368,7 @@ end
 
 class Win32API
 	NATIVE_ON_WINDOWS = true unless const_defined?("NATIVE_ON_WINDOWS")
-	TOLERATE_ERRORS = true
-	# unless const_defined?("TOLERATE_ERRORS")
+	TOLERATE_ERRORS = true unless const_defined?("TOLERATE_ERRORS")
 	LOG_NATIVE = false unless const_defined?("LOG_NATIVE")
 
 	alias_method :mkxp_native_initialize, :initialize
@@ -405,7 +401,6 @@ class Win32API
 
 		# Try native call (for actual DLLs on Windows)
 		@mkxp_native_available = false
-		@last_error = nil
 		begin
 			# For local DLLs on Windows, try native call with original names
 			if @is_local_dll && System.is_windows?
@@ -418,20 +413,17 @@ class Win32API
 			mkxp_native_initialize(dll_for_lookup, func_for_lookup, *args)
 			@mkxp_native_available = true
 			return
-		rescue => e
-			@last_error = e
+		rescue
 		end
 
 	end
 
 	alias_method :mkxp_native_call, :call
 	def call(*args)
-		# Use polyfill implementation if available
 		if @mkxp_wrap_impl
 			return @mkxp_wrap_impl.call(args)
 		end
 
-		# Use native Win32API if available
 		if @mkxp_native_available
 			if LOG_NATIVE
 				System.puts("[Win32API] [#{@dll}:#{@func}] #{args.to_s}")
@@ -439,14 +431,12 @@ class Win32API
 			return mkxp_native_call(*args)
 		end
 
-		# Error handling
 		if TOLERATE_ERRORS
 			System.puts("[Win32API] [#{@dll}:#{@func}] #{args.to_s}") if !@called
 			@called = true
 			return 0
 		else
-			error_msg = @last_error ? @last_error.message : "DLL or function not found"
-			raise RuntimeError, "[Win32API] [#{@dll}:#{@func}] #{error_msg}"
+			raise RuntimeError, "[Win32API] [#{@dll}:#{@func}] #{args.to_s}"
 		end
 	end
 end

--- a/scripts/preload/win32_wrap.rb
+++ b/scripts/preload/win32_wrap.rb
@@ -222,26 +222,6 @@ def memcpy_string(dst, src)
 	end
 end
 
-# safer replacement for memcpy_string
-def safe_memcpy_string(dst, src)
-	return false unless dst.is_a?(String)
-	return false if src.nil?
-	# ensure binary encoding to avoid multibyte surprises
-	dst.force_encoding('ASCII-8BIT') if dst.respond_to?(:force_encoding)
-	# expand destination if too short
-	if dst.bytesize < src.bytesize
-		dst << ("\x00" * (src.bytesize - dst.bytesize))
-	end
-	i = 0
-	src.each_byte do |b|
-		dst.setbyte(i, b)
-		i += 1
-	end
-	true
-end
-
-
-
 def state_pressed(states, sdl_scan)
 	return states[Scancodes::SDL[sdl_scan]]
 end
@@ -325,10 +305,7 @@ module Win32API_Impl
 		class GetCursorPos
 			def call(args)
 				out = [Input.mouse_x, Input.mouse_y].pack('ll')
-				unless safe_memcpy_string(args[0], out)
-					System.puts("[Win32API] GetCursorPos: invalid buffer (#{args[0].class})") if defined?(System) && Win32API::TOLERATE_ERRORS
-					return 0
-				end
+				memcpy_string(args[0], out)
 				return 1
 			end
 		end
@@ -344,10 +321,7 @@ module Win32API_Impl
 					rect[3] = Graphics.height
 				rescue
 				end
-				unless safe_memcpy_string(args[1], rect.pack('l4'))
-					System.puts("[Win32API] GetClientRect: invalid buffer (#{args[1].class})") if defined?(System) && Win32API::TOLERATE_ERRORS
-					return 0
-				end
+				memcpy_string(args[1], rect.pack('l4'))
 				return 1
 			end
 		end
@@ -375,13 +349,7 @@ def kappatalize(s)
 	s[0] = s[0].upcase
 	return s
 end
-# win32_wrap.rb (IMPROVED VERSION)
-# Support for local DLL paths with preserved function names
 
-# ... (keep all the Scancodes and helper functions as they were) ...
-
-# Helper to detect if a DLL name is a local/custom DLL path
-# Helper to detect if a DLL name is a local/custom DLL path
 # Helper to detect if a DLL name is a local/custom DLL path
 def is_local_dll_path?(dll_name)
 	# Explicitly look for .dll extension - if present, it's a custom DLL path
@@ -482,7 +450,4 @@ class Win32API
 		end
 	end
 end
-#game_dir = CFG["gameFolder"].to_s
-# fifoscriptpath = File.join(Dir.pwd, "testfifo.rb")
-#
-# load fifoscriptpath
+

--- a/scripts/preload/win32_wrap.rb
+++ b/scripts/preload/win32_wrap.rb
@@ -222,6 +222,26 @@ def memcpy_string(dst, src)
 	end
 end
 
+# safer replacement for memcpy_string
+def safe_memcpy_string(dst, src)
+	return false unless dst.is_a?(String)
+	return false if src.nil?
+	# ensure binary encoding to avoid multibyte surprises
+	dst.force_encoding('ASCII-8BIT') if dst.respond_to?(:force_encoding)
+	# expand destination if too short
+	if dst.bytesize < src.bytesize
+		dst << ("\x00" * (src.bytesize - dst.bytesize))
+	end
+	i = 0
+	src.each_byte do |b|
+		dst.setbyte(i, b)
+		i += 1
+	end
+	true
+end
+
+
+
 def state_pressed(states, sdl_scan)
 	return states[Scancodes::SDL[sdl_scan]]
 end
@@ -305,11 +325,16 @@ module Win32API_Impl
 		class GetCursorPos
 			def call(args)
 				out = [Input.mouse_x, Input.mouse_y].pack('ll')
-				memcpy_string(args[0], out)
+				unless safe_memcpy_string(args[0], out)
+					System.puts("[Win32API] GetCursorPos: invalid buffer (#{args[0].class})") if defined?(System) && Win32API::TOLERATE_ERRORS
+					return 0
+				end
 				return 1
 			end
 		end
 
+
+		# Example: GetClientRect.call (use same safe_memcpy_string)
 		class GetClientRect
 			def call(args)
 				return 0 if args[0] != 42
@@ -319,10 +344,14 @@ module Win32API_Impl
 					rect[3] = Graphics.height
 				rescue
 				end
-				memcpy_string(args[1], rect.pack('l4'))
+				unless safe_memcpy_string(args[1], rect.pack('l4'))
+					System.puts("[Win32API] GetClientRect: invalid buffer (#{args[1].class})") if defined?(System) && Win32API::TOLERATE_ERRORS
+					return 0
+				end
 				return 1
 			end
 		end
+
 
 		class ScreenToClient
 			def call(args)
@@ -346,10 +375,36 @@ def kappatalize(s)
 	s[0] = s[0].upcase
 	return s
 end
+# win32_wrap.rb (IMPROVED VERSION)
+# Support for local DLL paths with preserved function names
+
+# ... (keep all the Scancodes and helper functions as they were) ...
+
+# Helper to detect if a DLL name is a local/custom DLL path
+# Helper to detect if a DLL name is a local/custom DLL path
+# Helper to detect if a DLL name is a local/custom DLL path
+def is_local_dll_path?(dll_name)
+	# Explicitly look for .dll extension - if present, it's a custom DLL path
+	return true if dll_name.downcase.end_with?('.dll')
+
+	# Check for path separators or absolute paths
+	return true if dll_name.include?('/') || dll_name.include?('\\') ||
+	              dll_name.match?(/^[a-zA-Z]:/)
+
+	# Known system DLLs (simple names without extension)
+	system_dlls = ['kernel32', 'user32', 'advapi32', 'shell32', 'ole32', 'gdi32',
+	               'comctl32', 'comdlg32', 'winmm', 'winsock2', 'msvcrt']
+
+	return false if system_dlls.include?(dll_name.downcase)
+
+	# Default: treat unknown names as local
+	return true
+end
 
 class Win32API
 	NATIVE_ON_WINDOWS = true unless const_defined?("NATIVE_ON_WINDOWS")
-	TOLERATE_ERRORS = true unless const_defined?("TOLERATE_ERRORS")
+	TOLERATE_ERRORS = true
+	# unless const_defined?("TOLERATE_ERRORS")
 	LOG_NATIVE = false unless const_defined?("LOG_NATIVE")
 
 	alias_method :mkxp_native_initialize, :initialize
@@ -357,36 +412,58 @@ class Win32API
 		@dll = dll
 		@func = func
 		@called = false
+		@is_local_dll = is_local_dll_path?(dll)
 
-		dll = kappatalize(dll.chomp(".dll"))
-		func = kappatalize(func)
+		# For local DLL paths, preserve the original names
+		# For system DLLs (kernel32, user32, etc.), apply kappatalize
+		if @is_local_dll
+			dll_for_lookup = dll
+			func_for_lookup = func
+		else
+			dll_for_lookup = kappatalize(dll.chomp(".dll"))
+			func_for_lookup = kappatalize(func)
+		end
 
+		# First try to find a polyfill implementation (for cross-platform support)
 		if !System.is_windows? or !NATIVE_ON_WINDOWS
-			if Win32API_Impl.const_defined?(dll)
-				dll_impl = Win32API_Impl.const_get(dll)
-				if dll_impl.const_defined?(func)
-					@mkxp_wrap_impl = dll_impl.const_get(func).new
+			if Win32API_Impl.const_defined?(dll_for_lookup)
+				dll_impl = Win32API_Impl.const_get(dll_for_lookup)
+				if dll_impl.const_defined?(func_for_lookup)
+					@mkxp_wrap_impl = dll_impl.const_get(func_for_lookup).new
 					return
 				end
 			end
 		end
 
+		# Try native call (for actual DLLs on Windows)
 		@mkxp_native_available = false
+		@last_error = nil
 		begin
-			mkxp_native_initialize(@dll, @func, *args)
+			# For local DLLs on Windows, try native call with original names
+			if @is_local_dll && System.is_windows?
+				mkxp_native_initialize(dll, func, *args)
+				@mkxp_native_available = true
+				return
+			end
+
+			# For system DLLs, use the transformed names
+			mkxp_native_initialize(dll_for_lookup, func_for_lookup, *args)
 			@mkxp_native_available = true
 			return
-		rescue
+		rescue => e
+			@last_error = e
 		end
 
 	end
 
 	alias_method :mkxp_native_call, :call
 	def call(*args)
+		# Use polyfill implementation if available
 		if @mkxp_wrap_impl
 			return @mkxp_wrap_impl.call(args)
 		end
 
+		# Use native Win32API if available
 		if @mkxp_native_available
 			if LOG_NATIVE
 				System.puts("[Win32API] [#{@dll}:#{@func}] #{args.to_s}")
@@ -394,12 +471,18 @@ class Win32API
 			return mkxp_native_call(*args)
 		end
 
+		# Error handling
 		if TOLERATE_ERRORS
 			System.puts("[Win32API] [#{@dll}:#{@func}] #{args.to_s}") if !@called
 			@called = true
 			return 0
 		else
-			raise RuntimeError, "[Win32API] [#{@dll}:#{@func}] #{args.to_s}"
+			error_msg = @last_error ? @last_error.message : "DLL or function not found"
+			raise RuntimeError, "[Win32API] [#{@dll}:#{@func}] #{error_msg}"
 		end
 	end
 end
+#game_dir = CFG["gameFolder"].to_s
+# fifoscriptpath = File.join(Dir.pwd, "testfifo.rb")
+#
+# load fifoscriptpath


### PR DESCRIPTION

I tested some additional DLLs for standard RPG Maker VX Ace vs. the i686 Windows build of mkxpz, and here is what I found:

First, the libraries that modify bitmaps— `KGL2.klib`, `tktk_bitmap.dll`, `wfgallery.dll`, `TRGSSX.dll`, `wfbitmap.dll`, and `wfMessage.dll`—do not work. It looks like they use object_id pointers that differ in the mkxpz version.

Some libraries only work if an absolute path to the file is used. For example, `wfAudio.dll` (encrypted audio) and `wfcrypt.dll` (encrypted saves) require:
`Win32API.new('C:/wfAudio.dll', ...)` 
rather than the standard script format:
`Win32API.new('wfAudio', ...)`
( game decryption via `wfcrypt.dll` still isn't working for some reason).

The good news is that steam_api.dll works perfectly even without an absolute path. I was able to earn Steam achievements using 32-bit mkxpz.

 I’ve updated `win32_wrap.rb` to add support for scripts that require absolute paths, but I'm not sure anymore if it's even necessary to invest time in the i686 Windows build, since most of the libraries are for bitmap editing and don't work.
 
 I took one of the builds  from the Build system overhaul pull request.

