### PR TITLE
Fixes how program arguments are never sent to ARGV in the AppImage

### DIFF
--- a/linux/AppRun
+++ b/linux/AppRun
@@ -23,4 +23,4 @@ fi
 export LD_LIBRARY_PATH
 export SRCDIR=$PWD
 
-exec "$SELF_DIR/usr/bin/mkxp-z"
+exec "$SELF_DIR/usr/bin/mkxp-z" "$@"


### PR DESCRIPTION
A simple fix this time!

Since, like, in both the windows build and the basic linux binary, running `mkxp-z -Test` then running `p ARGV` gives an output of `["-Test"]` properly, so this makes the behavior consistent for the AppImage as well