### PR TITLE
Use RAII guards when acquiring mutexes

### DIFF
--- a/binding/binding-util.h
+++ b/binding/binding-util.h
@@ -362,19 +362,6 @@ static inline void _rb_define_module_function(VALUE module, const char *name,
     rb_define_module_function(module, name, RUBY_METHOD_FUNC(func), -1);
 }
 
-#define GFX_GUARD_EXC(exp)                                               \
-{                                                                        \
-GFX_LOCK;                                                                \
-try {                                                                    \
-exp                                                                      \
-} catch (const Exception &exc) {                                         \
-GFX_UNLOCK;                                                              \
-throw exc;                                                               \
-}                                                                        \
-GFX_UNLOCK;                                                              \
-}
-
-
 template <class C>
 static inline VALUE objectLoad(int argc, VALUE *argv, VALUE self) {
     const char *data;
@@ -657,7 +644,7 @@ if (NIL_P(propObj))                                                        \
 prop = 0;                                                                \
 else                                                                       \
 prop = getPrivateDataCheck<PropKlass>(propObj, PropKlass##Type);         \
-GFX_GUARD_EXC(k->set##PropName(prop);)                                         \
+{GFX_GUARD; k->set##PropName(prop);}                                         \
 rb_iv_set(self, prop_iv, propObj);                                         \
 return propObj;                                                            \
 }                                                                          \
@@ -681,7 +668,7 @@ Klass *k = getPrivateData<Klass>(self);                                    \
 VALUE propObj = *argv;                                                     \
 PropKlass *prop;                                                           \
 prop = getPrivateDataCheck<PropKlass>(propObj, PropKlass##Type);           \
-GFX_GUARD_EXC(k->set##PropName(*prop);)                                        \
+{GFX_GUARD; k->set##PropName(*prop);}                                        \
 return propObj;                                                            \
 }                                                                          \
 RB_METHOD_GUARD_END
@@ -704,7 +691,7 @@ rb_check_argc(argc, 1);                                                    \
 Klass *k = getPrivateData<Klass>(self);                                    \
 type value;                                                                \
 rb_##arg_fun##_arg(*argv, &value);                                         \
-GFX_GUARD_EXC(k->set##PropName(value);)                                        \
+{GFX_GUARD; k->set##PropName(value);}                                        \
 return *argv;                                                              \
 }                                                                          \
 RB_METHOD_GUARD_END

--- a/binding/bitmap-binding.cpp
+++ b/binding/bitmap-binding.cpp
@@ -50,7 +50,9 @@ void bitmapInitProps(Bitmap *b, VALUE self) {
     rb_iv_set(self, "font", fontObj);
 
     // Leave property as default nil if hasHires() is false.
-    GFX_GUARD_EXC(
+    {
+        GFX_GUARD;
+
         if (b->hasHires()) {
             b->assumeRubyGC();
             wrapProperty(self, b->getHires(), "hires", BitmapType);
@@ -63,7 +65,7 @@ void bitmapInitProps(Bitmap *b, VALUE self) {
         }
 
         b->setInitFont(font);
-    );
+    }
 }
 
 RB_METHOD_GUARD(bitmapInitialize) {
@@ -73,12 +75,14 @@ RB_METHOD_GUARD(bitmapInitialize) {
         char *filename;
         rb_get_args(argc, argv, "z", &filename RB_ARG_END);
         
-        GFX_GUARD_EXC(b = new Bitmap(filename);)
+        GFX_GUARD;
+        b = new Bitmap(filename);
     } else {
         int width, height;
         rb_get_args(argc, argv, "ii", &width, &height RB_ARG_END);
         
-        GFX_GUARD_EXC(b = new Bitmap(width, height);)
+        GFX_GUARD;
+        b = new Bitmap(width, height);
     }
     
     setPrivateData(self, b);
@@ -146,7 +150,8 @@ RB_METHOD_GUARD(bitmapBlt) {
     if (src) {
         srcRect = getPrivateDataCheck<Rect>(srcRectObj, RectType);
     
-        GFX_GUARD_EXC(b->blt(x, y, *src, srcRect->toIntRect(), opacity););
+        GFX_GUARD;
+        b->blt(x, y, *src, srcRect->toIntRect(), opacity);
     }
     
     return self;
@@ -172,8 +177,8 @@ RB_METHOD_GUARD(bitmapStretchBlt) {
         destRect = getPrivateDataCheck<Rect>(destRectObj, RectType);
         srcRect = getPrivateDataCheck<Rect>(srcRectObj, RectType);
         
-        GFX_GUARD_EXC(b->stretchBlt(destRect->toIntRect(), *src, srcRect->toIntRect(),
-                                    opacity););
+        GFX_GUARD;
+        b->stretchBlt(destRect->toIntRect(), *src, srcRect->toIntRect(), opacity);
     }
     
     return self;
@@ -195,7 +200,8 @@ RB_METHOD_GUARD(bitmapFillRect) {
         rect = getPrivateDataCheck<Rect>(rectObj, RectType);
         color = getPrivateDataCheck<Color>(colorObj, ColorType);
         
-        GFX_GUARD_EXC(b->fillRect(rect->toIntRect(), color->norm););
+        GFX_GUARD;
+        b->fillRect(rect->toIntRect(), color->norm);
     } else {
         int x, y, width, height;
         
@@ -204,7 +210,8 @@ RB_METHOD_GUARD(bitmapFillRect) {
         
         color = getPrivateDataCheck<Color>(colorObj, ColorType);
         
-        GFX_GUARD_EXC(b->fillRect(x, y, width, height, color->norm););
+        GFX_GUARD;
+        b->fillRect(x, y, width, height, color->norm);
     }
     
     return self;
@@ -216,7 +223,8 @@ RB_METHOD_GUARD(bitmapClear) {
     
     Bitmap *b = getPrivateData<Bitmap>(self);
 
-    GFX_GUARD_EXC(b->clear();)
+    GFX_GUARD;
+    b->clear();
     
     return self;
 }
@@ -232,8 +240,10 @@ RB_METHOD_GUARD(bitmapGetPixel) {
     Color value;
     if (b->surface() || b->megaSurface())
         value = b->getPixel(x, y);
-    else
-        GFX_GUARD_EXC(value = b->getPixel(x, y););
+    else {
+        GFX_GUARD;
+        value = b->getPixel(x, y);
+    }
     
     Color *color = new Color(value);
     
@@ -253,7 +263,8 @@ RB_METHOD_GUARD(bitmapSetPixel) {
     
     color = getPrivateDataCheck<Color>(colorObj, ColorType);
     
-    GFX_GUARD_EXC(b->setPixel(x, y, *color););
+    GFX_GUARD;
+    b->setPixel(x, y, *color);
     
     return self;
 }
@@ -266,7 +277,8 @@ RB_METHOD_GUARD(bitmapHueChange) {
     
     rb_get_args(argc, argv, "i", &hue RB_ARG_END);
     
-    GFX_GUARD_EXC(b->hueChange(hue););
+    GFX_GUARD;
+    b->hueChange(hue);
     
     return self;
 }
@@ -293,7 +305,8 @@ RB_METHOD_GUARD(bitmapDrawText) {
         
         rect = getPrivateDataCheck<Rect>(rectObj, RectType);
         
-        GFX_GUARD_EXC(b->drawText(rect->toIntRect(), str, align););
+        GFX_GUARD;
+        b->drawText(rect->toIntRect(), str, align);
     } else {
         int x, y, width, height;
         
@@ -308,7 +321,8 @@ RB_METHOD_GUARD(bitmapDrawText) {
                         &align RB_ARG_END);
         }
         
-        GFX_GUARD_EXC(b->drawText(x, y, width, height, str, align););
+        GFX_GUARD;
+        b->drawText(x, y, width, height, str, align);
     }
     
     return self;
@@ -350,7 +364,11 @@ RB_METHOD_GUARD(BitmapSetFont) {
     
     Font *prop = getPrivateDataCheck<Font>(propObj, FontType);
     if (prop) {
-        GFX_GUARD_EXC(b->setFont(*prop);)
+        {
+            GFX_GUARD;
+            b->setFont(*prop);
+        }
+
         
         VALUE f = rb_iv_get(self, "font");
         if (f) {
@@ -391,8 +409,8 @@ RB_METHOD_GUARD(bitmapGradientFillRect) {
         color1 = getPrivateDataCheck<Color>(color1Obj, ColorType);
         color2 = getPrivateDataCheck<Color>(color2Obj, ColorType);
         
-        GFX_GUARD_EXC(b->gradientFillRect(rect->toIntRect(), color1->norm, color2->norm,
-                                      vertical););
+        GFX_GUARD;
+        b->gradientFillRect(rect->toIntRect(), color1->norm, color2->norm, vertical);
     } else {
         int x, y, width, height;
         
@@ -402,8 +420,8 @@ RB_METHOD_GUARD(bitmapGradientFillRect) {
         color1 = getPrivateDataCheck<Color>(color1Obj, ColorType);
         color2 = getPrivateDataCheck<Color>(color2Obj, ColorType);
         
-        GFX_GUARD_EXC(b->gradientFillRect(x, y, width, height, color1->norm,
-                                      color2->norm, vertical););
+        GFX_GUARD;
+        b->gradientFillRect(x, y, width, height, color1->norm, color2->norm, vertical);
     }
     
     return self;
@@ -421,13 +439,15 @@ RB_METHOD_GUARD(bitmapClearRect) {
         
         rect = getPrivateDataCheck<Rect>(rectObj, RectType);
         
-        GFX_GUARD_EXC(b->clearRect(rect->toIntRect()););
+        GFX_GUARD;
+        b->clearRect(rect->toIntRect());
     } else {
         int x, y, width, height;
         
         rb_get_args(argc, argv, "iiii", &x, &y, &width, &height RB_ARG_END);
         
-        GFX_GUARD_EXC(b->clearRect(x, y, width, height););
+        GFX_GUARD;
+        b->clearRect(x, y, width, height);
     }
     
     return self;
@@ -439,7 +459,8 @@ RB_METHOD_GUARD(bitmapBlur) {
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    GFX_GUARD_EXC( b->blur(); );
+    GFX_GUARD;
+    b->blur();
     
     return Qnil;
 }
@@ -451,7 +472,8 @@ RB_METHOD_GUARD(bitmapRadialBlur) {
     int angle, divisions;
     rb_get_args(argc, argv, "ii", &angle, &divisions RB_ARG_END);
     
-    GFX_GUARD_EXC( b->radialBlur(angle, divisions); );
+    GFX_GUARD;
+    b->radialBlur(angle, divisions);
     
     return Qnil;
 }
@@ -464,7 +486,8 @@ RB_METHOD_GUARD(bitmapGetRawData) {
     int size = b->width() * b->height() * 4;
     VALUE ret = rb_str_new(0, size);
     
-    GFX_GUARD_EXC(b->getRaw(RSTRING_PTR(ret), size););
+    GFX_GUARD;
+    b->getRaw(RSTRING_PTR(ret), size);
     
     return ret;
 }
@@ -479,7 +502,8 @@ RB_METHOD_GUARD(bitmapSetRawData) {
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    GFX_GUARD_EXC(b->replaceRaw(RSTRING_PTR(str), RSTRING_LEN(str)););
+    GFX_GUARD;
+    b->replaceRaw(RSTRING_PTR(str), RSTRING_LEN(str));
     
     return self;
 }
@@ -494,7 +518,8 @@ RB_METHOD_GUARD(bitmapSaveToFile) {
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    GFX_GUARD_EXC(b->saveToFile(RSTRING_PTR(str)););
+    GFX_GUARD;
+    b->saveToFile(RSTRING_PTR(str));
     
     return RUBY_Qnil;
 }
@@ -507,11 +532,8 @@ RB_METHOD_GUARD(bitmapGetMega){
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    VALUE ret;
-    
-    GFX_GUARD_EXC(ret = rb_bool_new(b->isMega()););
-    
-    return ret;
+    GFX_GUARD;
+    return rb_bool_new(b->isMega());
 }
 RB_METHOD_GUARD_END
 
@@ -522,11 +544,8 @@ RB_METHOD_GUARD(bitmapGetAnimated){
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    VALUE ret;
-    
-    GFX_GUARD_EXC(ret = rb_bool_new(b->isAnimated()););
-    
-    return ret;
+    GFX_GUARD;
+    return rb_bool_new(b->isAnimated());
 }
 RB_METHOD_GUARD_END
 
@@ -537,11 +556,8 @@ RB_METHOD_GUARD(bitmapGetPlaying){
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    VALUE ret;
-    
-    GFX_GUARD_EXC(ret = rb_bool_new(b->isPlaying()););
-    
-    return ret;
+    GFX_GUARD;
+    return rb_bool_new(b->isPlaying());
 }
 RB_METHOD_GUARD_END
 
@@ -554,7 +570,12 @@ RB_METHOD_GUARD(bitmapSetPlaying){
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    GFX_GUARD_EXC((play) ? b->play() : b->stop(););
+    GFX_GUARD;
+    if (play) {
+        b->play();
+    } else {
+        b->stop();
+    }
     
     return RUBY_Qnil;
 }
@@ -566,7 +587,8 @@ RB_METHOD_GUARD(bitmapPlay){
     rb_check_argc(argc, 0);
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    GFX_GUARD_EXC(b->play(););
+    GFX_GUARD;
+    b->play();
     
     return RUBY_Qnil;
 }
@@ -578,7 +600,8 @@ RB_METHOD_GUARD(bitmapStop){
     rb_check_argc(argc, 0);
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    GFX_GUARD_EXC(b->stop(););
+    GFX_GUARD;
+    b->stop();
     
     return RUBY_Qnil;
 }
@@ -593,7 +616,8 @@ RB_METHOD_GUARD(bitmapGotoStop){
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    GFX_GUARD_EXC(b->gotoAndStop(frame););
+    GFX_GUARD;
+    b->gotoAndStop(frame);
     
     return RUBY_Qnil;
 }
@@ -608,7 +632,8 @@ RB_METHOD_GUARD(bitmapGotoPlay){
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    GFX_GUARD_EXC(b->gotoAndPlay(frame););
+    GFX_GUARD;
+    b->gotoAndPlay(frame);
     
     return RUBY_Qnil;
 }
@@ -621,11 +646,8 @@ RB_METHOD_GUARD(bitmapFrames){
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    int ret;
-    
-    GFX_GUARD_EXC(ret = b->numFrames(););
-    
-    return INT2NUM(ret);
+    GFX_GUARD;
+    return INT2NUM(b->numFrames());
 }
 RB_METHOD_GUARD_END
 
@@ -638,9 +660,8 @@ RB_METHOD_GUARD(bitmapCurrentFrame){
     
     int ret;
     
-    GFX_GUARD_EXC(ret = b->currentFrameI(););
-    
-    return INT2NUM(ret);
+    GFX_GUARD;
+    return INT2NUM(b->currentFrameI());
 }
 RB_METHOD_GUARD_END
 
@@ -664,11 +685,8 @@ RB_METHOD_GUARD(bitmapAddFrame){
         if (pos < 0) pos = 0;
     }
     
-    int ret;
-    
-    GFX_GUARD_EXC(ret = b->addFrame(*src, pos););
-    
-    return INT2NUM(ret);
+    GFX_GUARD;
+    return INT2NUM(b->addFrame(*src, pos));
 }
 RB_METHOD_GUARD_END
 
@@ -687,7 +705,8 @@ RB_METHOD_GUARD(bitmapRemoveFrame){
         if (pos < 0) pos = 0;
     }
     
-    GFX_GUARD_EXC(b->removeFrame(pos););
+    GFX_GUARD;
+    b->removeFrame(pos);
     
     return RUBY_Qnil;
 }
@@ -700,13 +719,9 @@ RB_METHOD_GUARD(bitmapNextFrame){
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    GFX_GUARD_EXC(b->nextFrame(););
-    
-    int ret;
-    
-    GFX_GUARD_EXC(ret = b->currentFrameI(););
-    
-    return INT2NUM(ret);
+    GFX_GUARD;
+    b->nextFrame();
+    return INT2NUM(b->currentFrameI());
 }
 RB_METHOD_GUARD_END
 
@@ -717,13 +732,9 @@ RB_METHOD_GUARD(bitmapPreviousFrame){
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    GFX_GUARD_EXC(b->previousFrame(););
-    
-    int ret;
-    
-    GFX_GUARD_EXC(ret = b->currentFrameI(););
-    
-    return INT2NUM(ret);
+    GFX_GUARD;
+    b->previousFrame();
+    return INT2NUM(b->currentFrameI());
 }
 RB_METHOD_GUARD_END
 
@@ -735,15 +746,13 @@ RB_METHOD_GUARD(bitmapSetFPS){
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    GFX_GUARD_EXC(
-              if (RB_TYPE_P(fps, RUBY_T_FLOAT)) {
+    GFX_GUARD;
+    if (RB_TYPE_P(fps, RUBY_T_FLOAT)) {
         b->setAnimationFPS(RFLOAT_VALUE(fps));
-    }
-              else {
+    } else {
         b->setAnimationFPS(NUM2INT(fps));
     }
-              );
-    
+
     return RUBY_Qnil;
 }
 RB_METHOD_GUARD_END
@@ -755,11 +764,7 @@ RB_METHOD_GUARD(bitmapGetFPS){
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    float ret;
-    
-    ret = b->getAnimationFPS();
-    
-    return rb_float_new(ret);
+    return rb_float_new(b->getAnimationFPS());
 }
 RB_METHOD_GUARD_END
 
@@ -771,7 +776,8 @@ RB_METHOD_GUARD(bitmapSetLooping){
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    GFX_GUARD_EXC(b->setLooping(loop););
+    GFX_GUARD;
+    b->setLooping(loop);
     
     return rb_bool_new(loop);
 }
@@ -784,9 +790,7 @@ RB_METHOD_GUARD(bitmapGetLooping){
     
     Bitmap *b = getPrivateData<Bitmap>(self);
     
-    bool ret;
-    ret = b->getLooping();
-    return rb_bool_new(ret);
+    return rb_bool_new(b->getLooping());
 }
 RB_METHOD_GUARD_END
 
@@ -802,7 +806,8 @@ RB_METHOD_GUARD(bitmapSnapToBitmap) {
     Bitmap *newbitmap = 0;
     int pos = (position == RUBY_Qnil) ? -1 : NUM2INT(position);
     
-    GFX_GUARD_EXC(newbitmap = new Bitmap(*b, pos););
+    GFX_GUARD;
+    newbitmap = new Bitmap(*b, pos);
     
     VALUE ret = rb_obj_alloc(rb_class_of(self));
     
@@ -831,7 +836,8 @@ RB_METHOD_GUARD(bitmapInitializeCopy) {
     Bitmap *orig = getPrivateData<Bitmap>(origObj);
     Bitmap *b = 0;
     
-    GFX_GUARD_EXC(b = new Bitmap(*orig););
+    GFX_GUARD;
+    b = new Bitmap(*orig);
     
     bitmapInitProps(b, self);
     b->setFont(orig->getFont());
@@ -883,7 +889,8 @@ RB_METHOD_GUARD(bitmapKglSubtractRect) {
     if (src) {
         srcRect = getPrivateDataCheck<Rect>(srcRectObj, RectType);
         IntRect srcIntRect = srcRect->toIntRect();
-        GFX_GUARD_EXC(b->stretchBlt(IntRect(x, y, abs(srcIntRect.w), abs(srcIntRect.h)), *src, srcIntRect, opacity, false, Bitmap::KGL_SUBTRACT););
+        GFX_GUARD;
+        b->stretchBlt(IntRect(x, y, abs(srcIntRect.w), abs(srcIntRect.h)), *src, srcIntRect, opacity, false, Bitmap::KGL_SUBTRACT);
     }
 
     return Qnil;

--- a/binding/bitmap-binding.cpp
+++ b/binding/bitmap-binding.cpp
@@ -806,8 +806,10 @@ RB_METHOD_GUARD(bitmapSnapToBitmap) {
     Bitmap *newbitmap = 0;
     int pos = (position == RUBY_Qnil) ? -1 : NUM2INT(position);
     
-    GFX_GUARD;
-    newbitmap = new Bitmap(*b, pos);
+    {
+        GFX_GUARD;
+        newbitmap = new Bitmap(*b, pos);
+    }
     
     VALUE ret = rb_obj_alloc(rb_class_of(self));
     
@@ -836,8 +838,10 @@ RB_METHOD_GUARD(bitmapInitializeCopy) {
     Bitmap *orig = getPrivateData<Bitmap>(origObj);
     Bitmap *b = 0;
     
-    GFX_GUARD;
-    b = new Bitmap(*orig);
+    {
+        GFX_GUARD;
+        b = new Bitmap(*orig);
+    }
     
     bitmapInitProps(b, self);
     b->setFont(orig->getFont());

--- a/binding/graphics-binding.cpp
+++ b/binding/graphics-binding.cpp
@@ -28,10 +28,8 @@
 
 RB_METHOD(graphicsDelta) {
     RB_UNUSED_PARAM;
-    GFX_LOCK;
-    VALUE ret = rb_float_new(shState->graphics().getDelta());
-    GFX_UNLOCK;
-    return ret;
+    GFX_GUARD;
+    return rb_float_new(shState->graphics().getDelta());
 }
 
 RB_METHOD_GUARD(graphicsUpdate)
@@ -39,7 +37,8 @@ RB_METHOD_GUARD(graphicsUpdate)
     RB_UNUSED_PARAM;
 #if RAPI_MAJOR >= 2
     drop_gvl_guard([](void*) -> void* {
-        GFX_GUARD_EXC( shState->graphics().update(); );
+        GFX_GUARD;
+        shState->graphics().update();
         return 0;
     }, 0, 0, 0);
 #else
@@ -52,10 +51,8 @@ RB_METHOD_GUARD_END
 RB_METHOD(graphicsAverageFrameRate)
 {
     RB_UNUSED_PARAM;
-    GFX_LOCK;
-    VALUE ret = rb_float_new(shState->graphics().averageFrameRate());
-    GFX_UNLOCK;
-    return ret;
+    GFX_GUARD;
+    return rb_float_new(shState->graphics().averageFrameRate());
 }
 
 RB_METHOD_GUARD(graphicsFreeze)
@@ -64,7 +61,8 @@ RB_METHOD_GUARD(graphicsFreeze)
     
 #if RAPI_MAJOR >= 2
     drop_gvl_guard([](void*) -> void* {
-        GFX_GUARD_EXC( shState->graphics().freeze(); );
+        GFX_GUARD;
+        shState->graphics().freeze();
         return 0;
     }, 0, 0, 0);
 #else
@@ -96,14 +94,15 @@ RB_METHOD_GUARD(graphicsTransition)
 #if RAPI_MAJOR >= 2
     drop_gvl_guard([](void *args) -> void* {
         TransitionArgs &a = *((TransitionArgs*)args);
-        GFX_GUARD_EXC( shState->graphics().transition(a.duration,
-                                                      a.filename,
-                                                      a.vague
-                                                     ); );
+        GFX_GUARD;
+        shState->graphics().transition(a.duration, a.filename, a.vague);
         return 0;
     }, &args, 0, 0);
 #else
-    GFX_GUARD_EXC( shState->graphics().transition(duration, filename, vague); )
+    {
+        GFX_GUARD;
+        shState->graphics().transition(duration, filename, vague);
+    }
 #endif
     
     return Qnil;
@@ -114,9 +113,8 @@ RB_METHOD(graphicsFrameReset)
 {
     RB_UNUSED_PARAM;
     
-    GFX_LOCK;
+    GFX_GUARD;
     shState->graphics().frameReset();
-    GFX_UNLOCK;
     
     return Qnil;
 }
@@ -132,9 +130,7 @@ RB_METHOD(graphics##Set##PropName) \
 RB_UNUSED_PARAM; \
 int value; \
 rb_get_args(argc, argv, "i", &value RB_ARG_END); \
-GFX_LOCK; \
-shState->graphics().set##PropName(value); \
-GFX_UNLOCK; \
+{GFX_GUARD; shState->graphics().set##PropName(value);} \
 return rb_fix_new(value); \
 }
 
@@ -149,9 +145,7 @@ RB_METHOD(graphics##Set##PropName) \
 RB_UNUSED_PARAM; \
 bool value; \
 rb_get_args(argc, argv, "b", &value RB_ARG_END); \
-GFX_LOCK; \
-shState->graphics().set##PropName(value); \
-GFX_UNLOCK; \
+{GFX_GUARD; shState->graphics().set##PropName(value);} \
 return rb_bool_new(value); \
 }
 
@@ -166,9 +160,7 @@ RB_METHOD(graphics##Set##PropName) \
 RB_UNUSED_PARAM; \
 double value; \
 rb_get_args(argc, argv, "f", &value RB_ARG_END); \
-GFX_LOCK; \
-shState->graphics().set##PropName(value); \
-GFX_UNLOCK; \
+{GFX_GUARD; shState->graphics().set##PropName(value);} \
 return rb_float_new(value); \
 }
 
@@ -208,7 +200,8 @@ RB_METHOD_GUARD(graphicsWait)
     rb_get_args(argc, argv, "i", &duration RB_ARG_END);
 #if RAPI_MAJOR >= 2
     drop_gvl_guard([](void* d) -> void* {
-        GFX_GUARD_EXC( shState->graphics().wait(*(int*)d); );
+        GFX_GUARD;
+        shState->graphics().wait(*(int*)d);
         return 0;
     }, (int*)&duration, 0, 0);
 #else
@@ -227,7 +220,8 @@ RB_METHOD_GUARD(graphicsFadeout)
     
 #if RAPI_MAJOR >= 2
     drop_gvl_guard([](void* d) -> void* {
-        GFX_GUARD_EXC( shState->graphics().fadeout(*(int*)d); );
+        GFX_GUARD;
+        shState->graphics().fadeout(*(int*)d);
         return 0;
     }, (int*)&duration, 0, 0);
 #else
@@ -247,7 +241,8 @@ RB_METHOD_GUARD(graphicsFadein)
     
 #if RAPI_MAJOR >= 2
     drop_gvl_guard([](void* d) -> void* {
-        GFX_GUARD_EXC( shState->graphics().fadein(*(int*)d); );
+        GFX_GUARD;
+        shState->graphics().fadein(*(int*)d);
         return 0;
     }, (int*)&duration, 0, 0);
 #else
@@ -266,7 +261,10 @@ RB_METHOD_GUARD(graphicsSnapToBitmap)
     
     Bitmap *result = 0;
     
-    GFX_GUARD_EXC( result = shState->graphics().snapToBitmap(); );
+    {
+        GFX_GUARD;
+        result = shState->graphics().snapToBitmap();
+    }
     
     VALUE obj = wrapObject(result, BitmapType);
     bitmapInitProps(result, obj);
@@ -282,9 +280,8 @@ RB_METHOD(graphicsResizeScreen)
     int width, height;
     rb_get_args(argc, argv, "ii", &width, &height RB_ARG_END);
     
-    GFX_LOCK;
+    GFX_GUARD;
     shState->graphics().resizeScreen(width, height);
-    GFX_UNLOCK;
     
     return Qnil;
 }
@@ -297,10 +294,8 @@ RB_METHOD(graphicsResizeWindow)
     bool center = false;
     rb_get_args(argc, argv, "ii|b", &width, &height, &center RB_ARG_END);
     
-    
-    GFX_LOCK;
+    GFX_GUARD;
     shState->graphics().resizeWindow(width, height, center);
-    GFX_UNLOCK;
     
     return Qnil;
 }
@@ -309,7 +304,8 @@ RB_METHOD_GUARD(graphicsReset)
 {
     RB_UNUSED_PARAM;
     
-    GFX_GUARD_EXC( shState->graphics().reset(); );
+    GFX_GUARD;
+    shState->graphics().reset();
     
     return Qnil;
 }
@@ -331,7 +327,10 @@ typedef struct {
 
 void *playMovieInternal(void *args) {
     PlayMovieArgs *a = (PlayMovieArgs*)args;
-    GFX_GUARD_EXC( shState->graphics().playMovie(a->filename, a->volume, a->skippable); );
+    {
+        GFX_GUARD;
+        shState->graphics().playMovie(a->filename, a->volume, a->skippable);
+    }
     
     // Signals for shutdown or reset only make playMovie quit early,
     // so check again
@@ -370,7 +369,8 @@ RB_METHOD_GUARD_END
 
 void graphicsScreenshotInternal(const char *filename)
 {
-    GFX_GUARD_EXC(shState->graphics().screenshot(filename););
+    GFX_GUARD;
+    shState->graphics().screenshot(filename);
 }
 
 RB_METHOD_GUARD(graphicsScreenshot)

--- a/binding/plane-binding.cpp
+++ b/binding/plane-binding.cpp
@@ -36,12 +36,11 @@ RB_METHOD(planeInitialize) {
 
   setPrivateData(self, p);
 
-    GFX_LOCK;
+  GFX_GUARD;
   p->initDynAttribs();
 
   wrapProperty(self, &p->getColor(), "color", ColorType);
   wrapProperty(self, &p->getTone(), "tone", ToneType);
-    GFX_UNLOCK;
 
   return self;
 }

--- a/binding/sceneelement-binding.h
+++ b/binding/sceneelement-binding.h
@@ -48,7 +48,8 @@ RB_METHOD_GUARD(sceneElementSetZ)
 	int z;
 	rb_get_args(argc, argv, "i", &z RB_ARG_END);
 
-	GFX_GUARD_EXC( se->setZ(z); );
+	GFX_GUARD;
+	se->setZ(z); 
 
 	return rb_fix_new(z);
 }
@@ -76,7 +77,8 @@ RB_METHOD_GUARD(sceneElementSetVisible)
 	bool visible;
 	rb_get_args(argc, argv, "b", &visible RB_ARG_END);
 
-	GFX_GUARD_EXC( se->setVisible(visible); );
+	GFX_GUARD;
+	se->setVisible(visible); 
 
 	return rb_bool_new(visible);
 }

--- a/binding/sprite-binding.cpp
+++ b/binding/sprite-binding.cpp
@@ -35,7 +35,7 @@ DEF_ALLOCFUNC(Sprite);
 #endif
 
 RB_METHOD(spriteInitialize) {
-    GFX_LOCK;
+    GFX_GUARD;
     Sprite *s = viewportElementInitialize<Sprite>(argc, argv, self);
     
     setPrivateData(self, s);
@@ -47,7 +47,6 @@ RB_METHOD(spriteInitialize) {
     wrapProperty(self, &s->getColor(), "color", ColorType);
     wrapProperty(self, &s->getTone(), "tone", ToneType);
     
-    GFX_UNLOCK;
     return self;
 }
 

--- a/binding/tilemap-binding.cpp
+++ b/binding/tilemap-binding.cpp
@@ -47,12 +47,11 @@ RB_METHOD(tilemapAutotilesSet) {
     
     Bitmap *bitmap = getPrivateDataCheck<Bitmap>(bitmapObj, BitmapType);
     
-    GFX_LOCK;
+    GFX_GUARD;
     a->set(i, bitmap);
     
     VALUE ary = rb_iv_get(self, "array");
     rb_ary_store(ary, i, bitmapObj);
-    GFX_UNLOCK;
     return self;
 }
 
@@ -86,7 +85,7 @@ RB_METHOD(tilemapInitialize) {
     if (!NIL_P(viewportObj))
         viewport = getPrivateDataCheck<Viewport>(viewportObj, ViewportType);
     
-    GFX_LOCK;
+    GFX_GUARD;
     /* Construct object */
     t = new Tilemap(viewport);
     
@@ -119,7 +118,6 @@ RB_METHOD(tilemapInitialize) {
      * alive at the same time */
     rb_iv_set(autotilesObj, "tilemap", self);
     
-    GFX_UNLOCK;
     return self;
 }
 
@@ -134,9 +132,8 @@ RB_METHOD(tilemapUpdate) {
     
     Tilemap *t = getPrivateData<Tilemap>(self);
     
-    GFX_LOCK;
+    GFX_GUARD;
     t->update();
-    GFX_UNLOCK;
     
     return Qnil;
 }

--- a/binding/tilemapvx-binding.cpp
+++ b/binding/tilemapvx-binding.cpp
@@ -41,7 +41,7 @@ DEF_ALLOCFUNC(TilemapVX);
 RB_METHOD(tilemapVXInitialize) {
     TilemapVX *t;
     
-    GFX_LOCK;
+    GFX_GUARD;
     /* Get parameters */
     VALUE viewportObj = Qnil;
     Viewport *viewport = 0;
@@ -79,7 +79,6 @@ RB_METHOD(tilemapVXInitialize) {
      * alive at the same time */
     rb_iv_set(autotilesObj, "tilemap", self);
     
-    GFX_UNLOCK;
     return self;
 }
 
@@ -122,12 +121,11 @@ RB_METHOD(tilemapVXBitmapsSet) {
     
     Bitmap *bitmap = getPrivateDataCheck<Bitmap>(bitmapObj, BitmapType);
     
-    GFX_LOCK;
+    GFX_GUARD;
     a->set(i, bitmap);
     
     VALUE ary = rb_iv_get(self, "array");
     rb_ary_store(ary, i, bitmapObj);
-    GFX_UNLOCK;
     return self;
 }
 

--- a/binding/viewport-binding.cpp
+++ b/binding/viewport-binding.cpp
@@ -35,40 +35,39 @@ DEF_ALLOCFUNC(Viewport);
 
 RB_METHOD(viewportInitialize) {
     Viewport *v;
-    
+    VALUE rectObj;
+    Rect *rect;
+    int x, y, width, height;
+
     if (argc == 0 && rgssVer >= 3) {
-        GFX_LOCK;
-        v = new Viewport();
     } else if (argc == 1) {
         /* The rect arg is only used to init the viewport,
          * and does NOT replace its 'rect' property */
-        VALUE rectObj;
-        Rect *rect;
-        
         rb_get_args(argc, argv, "o", &rectObj RB_ARG_END);
-        
         rect = getPrivateDataCheck<Rect>(rectObj, RectType);
-        
-        GFX_LOCK;
+    } else {
+        rb_get_args(argc, argv, "iiii", &x, &y, &width, &height RB_ARG_END);
+    }
+
+    GFX_GUARD;
+
+    if (argc == 0 && rgssVer >= 3) {
+        v = new Viewport();
+    } else if (argc == 1) {
         v = new Viewport(rect);
     } else {
-        int x, y, width, height;
-        
-        rb_get_args(argc, argv, "iiii", &x, &y, &width, &height RB_ARG_END);
-        GFX_LOCK;
         v = new Viewport(x, y, width, height);
     }
-    
+
     setPrivateData(self, v);
-    
+
     /* Wrap property objects */
     v->initDynAttribs();
-    
+
     wrapProperty(self, &v->getRect(), "rect", RectType);
     wrapProperty(self, &v->getColor(), "color", ColorType);
     wrapProperty(self, &v->getTone(), "tone", ToneType);
-    
-    GFX_UNLOCK;
+
     return self;
 }
 

--- a/binding/viewportelement-binding.h
+++ b/binding/viewportelement-binding.h
@@ -56,7 +56,10 @@ RB_METHOD_GUARD(viewportElementSetViewport)
 	if (!NIL_P(viewportObj))
 		viewport = getPrivateDataCheck<Viewport>(viewportObj, ViewportType);
 
-	GFX_GUARD_EXC( ve->setViewport(viewport); );
+	{
+		GFX_GUARD;
+		ve->setViewport(viewport);
+	}
 
 	rb_iv_set(self, "viewport", viewportObj);
 
@@ -79,14 +82,13 @@ viewportElementInitialize(int argc, VALUE *argv, VALUE self)
 		viewport = getPrivateDataCheck<Viewport>(viewportObj, ViewportType);
 	}
 
-    GFX_LOCK;
+	GFX_GUARD;
 	/* Construct object */
 	C *ve = new C(viewport);
 
     
 	/* Set property objects */
 	rb_iv_set(self, "viewport", viewportObj);
-    GFX_UNLOCK;
 	return ve;
 }
 

--- a/binding/window-binding.cpp
+++ b/binding/window-binding.cpp
@@ -31,7 +31,7 @@ DEF_ALLOCFUNC(Window);
 #endif
 
 RB_METHOD(windowInitialize) {
-    GFX_LOCK;
+    GFX_GUARD;
     Window *w = viewportElementInitialize<Window>(argc, argv, self);
     
     setPrivateData(self, w);
@@ -40,7 +40,6 @@ RB_METHOD(windowInitialize) {
     
     wrapProperty(self, &w->getCursorRect(), "cursor_rect", RectType);
     
-    GFX_UNLOCK;
     return self;
 }
 
@@ -49,7 +48,8 @@ RB_METHOD_GUARD(windowUpdate) {
     
     Window *w = getPrivateData<Window>(self);
     
-    GFX_GUARD_EXC(w->update(););
+    GFX_GUARD;
+    w->update();
     
     return Qnil;
 }

--- a/binding/windowvx-binding.cpp
+++ b/binding/windowvx-binding.cpp
@@ -37,15 +37,18 @@ void bitmapInitProps(Bitmap *b, VALUE self);
 
 RB_METHOD(windowVXInitialize) {
   WindowVX *w;
+  int x, y, width, height;
 
-    GFX_LOCK;
   if (rgssVer >= 3) {
-    int x, y, width, height;
     x = y = width = height = 0;
 
     if (argc == 4)
       rb_get_args(argc, argv, "iiii", &x, &y, &width, &height RB_ARG_END);
+  }
 
+  GFX_GUARD;
+
+  if (rgssVer >= 3) {
     w = new WindowVX(x, y, width, height);
   } else {
     w = viewportElementInitialize<WindowVX>(argc, argv, self);
@@ -65,7 +68,6 @@ RB_METHOD(windowVXInitialize) {
   bitmapInitProps(contents, contentsObj);
   rb_iv_set(self, "contents", contentsObj);
 
-    GFX_UNLOCK;
   return self;
 }
 
@@ -74,9 +76,8 @@ RB_METHOD(windowVXUpdate) {
 
   WindowVX *w = getPrivateData<WindowVX>(self);
 
-    GFX_LOCK;
+  GFX_GUARD;
   w->update();
-    GFX_UNLOCK;
 
   return Qnil;
 }
@@ -87,9 +88,8 @@ RB_METHOD(windowVXMove) {
   int x, y, width, height;
   rb_get_args(argc, argv, "iiii", &x, &y, &width, &height RB_ARG_END);
 
-    GFX_LOCK;
+  GFX_GUARD;
   w->move(x, y, width, height);
-    GFX_UNLOCK;
     
   return Qnil;
 }

--- a/src/audio/alstream.cpp
+++ b/src/audio/alstream.cpp
@@ -31,7 +31,6 @@
 #include "sdl-util.h"
 #include "debugwriter.h"
 
-#include <SDL_mutex.h>
 #include <SDL_thread.h>
 #include <SDL_timer.h>
 
@@ -53,8 +52,6 @@ ALStream::ALStream(LoopMode loopMode,
 	for (int i = 0; i < STREAM_BUFS; ++i)
 		alBuf[i] = AL::Buffer::gen();
 
-	pauseMut = SDL_CreateMutex();
-
 	threadName = std::string("al_stream (") + threadId + ")";
 }
 
@@ -67,8 +64,6 @@ ALStream::~ALStream()
 
 	for (int i = 0; i < STREAM_BUFS; ++i)
 		AL::Buffer::del(alBuf[i]);
-
-	SDL_DestroyMutex(pauseMut);
 }
 
 void ALStream::close()
@@ -308,26 +303,22 @@ void ALStream::startStream(double offset)
 
 void ALStream::pauseStream()
 {
-	SDL_LockMutex(pauseMut);
+	std::lock_guard<std::mutex> guard(pauseMut);
 
 	if (AL::Source::getState(alSrc) != AL_PLAYING)
 		preemptPause = true;
 	else
 		AL::Source::pause(alSrc);
-
-	SDL_UnlockMutex(pauseMut);
 }
 
 void ALStream::resumeStream()
 {
-	SDL_LockMutex(pauseMut);
+	std::lock_guard<std::mutex> guard(pauseMut);
 
 	if (preemptPause)
 		preemptPause = false;
 	else
 		AL::Source::play(alSrc);
-
-	SDL_UnlockMutex(pauseMut);
 }
 
 void ALStream::checkStopped()

--- a/src/audio/alstream.h
+++ b/src/audio/alstream.h
@@ -25,6 +25,7 @@
 #include "al-util.h"
 #include "sdl-util.h"
 
+#include <mutex>
 #include <string>
 #include <SDL_rwops.h>
 
@@ -52,7 +53,7 @@ struct ALStream
 
 	std::string threadName;
 
-	SDL_mutex *pauseMut;
+	std::mutex pauseMut;
 	bool preemptPause;
 
 	/* When this flag isn't set and alSrc is

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -101,6 +101,20 @@ struct AudioPrivate
         return bgmTracks[index];
     }
 
+	void lock()
+	{
+		for (AudioStream *track : bgmTracks) {
+			track->lock();
+		}
+	}
+
+	void unlock()
+	{
+		for (AudioStream *track : bgmTracks) {
+			track->unlock();
+		}
+	}
+
 	void meWatchFun()
 	{
 		const float fadeOutStep = 1.f / (200  / AUDIO_SLEEP);
@@ -117,7 +131,7 @@ struct AudioPrivate
 			{
 			case MeNotPlaying:
 			{
-				me.lockStream();
+				std::lock_guard<AudioStream> guard(me);
 
 				if (me.stream.queryState() == ALStream::Playing)
 				{
@@ -128,19 +142,16 @@ struct AudioPrivate
 					meWatch.state = BgmFadingOut;
 				}
 
-				me.unlockStream();
-
 				break;
 			}
 
 			case BgmFadingOut :
 			{
-				me.lockStream();
+				std::lock_guard<AudioStream> guard(me);
 
 				if (me.stream.queryState() != ALStream::Playing)
 				{
 					/* ME has ended while fading OUT BGM. -> FadeInBGM */
-					me.unlockStream();
 					meWatch.state = BgmFadingIn;
 
 					break;
@@ -150,54 +161,53 @@ struct AudioPrivate
                 
                 for (int i = 0; i < (int)(bgmTracks.size()); i++) {
                     AudioStream *track = bgmTracks[i];
-                    
-                    track->lockStream();
-                    
-                    float vol = track->getVolume(AudioStream::External);
-                    vol -= fadeOutStep;
-                    
-                    if (vol < 0 || track->stream.queryState() != ALStream::Playing) {
-                        /* Either BGM has fully faded out, or stopped midway. -> MePlaying */
-                        track->setVolume(AudioStream::External, 0);
-                        track->stream.pause();
-                        track->unlockStream();
-                        
+                    bool checkForPlayingTracks = false;
+
+                    {
+                        std::lock_guard<AudioStream> trackGuard(*track);
+
+                        float vol = track->getVolume(AudioStream::External);
+                        vol -= fadeOutStep;
+
+                        if (vol < 0 || track->stream.queryState() != ALStream::Playing) {
+                            /* Either BGM has fully faded out, or stopped midway. -> MePlaying */
+                            track->setVolume(AudioStream::External, 0);
+                            track->stream.pause();
+                            checkForPlayingTracks = true;
+                        } else {
+                            track->setVolume(AudioStream::External, vol);
+                        }
+                    }
+
+                    if (checkForPlayingTracks) {
                         // check to see if there are any tracks still playing,
                         // and if the last one was ended this round, this branch should exit
                         std::vector<AudioStream*> playingTracks;
                         for (auto t : bgmTracks)
                             if (t->stream.queryState() == ALStream::Playing)
                                 playingTracks.push_back(t);
-                        
-                        
+
                         if (playingTracks.size() <= 0 && !shouldBreak) shouldBreak = true;
                         continue;
                     }
-                    
-                    track->setVolume(AudioStream::External, vol);
-                    track->unlockStream();
-                    
                 }
                 if (shouldBreak) {
                     meWatch.state = MePlaying;
-                    me.unlockStream();
                     break;
                 }
                 
-				me.unlockStream();
-
 				break;
 			}
 
 			case MePlaying :
 			{
-				me.lockStream();
+				std::lock_guard<AudioStream> guard(me);
 
 				if (me.stream.queryState() != ALStream::Playing)
                 {
                     /* ME has ended */
                     for (auto track : bgmTracks) {
-                        track->lockStream();
+                        std::lock_guard<AudioStream> trackGuard(*track);
                         track->extPaused = false;
                         
                         ALStream::State sState = track->stream.queryState();
@@ -216,20 +226,15 @@ struct AudioPrivate
                             
                             meWatch.state = MeNotPlaying;
                         }
-                        
-                        track->unlockStream();
                     }
 				}
-
-                me.unlockStream();
 
 				break;
 			}
 
 			case BgmFadingIn :
 			{
-                for (auto track : bgmTracks)
-                    track->lockStream();
+				std::lock_guard<AudioPrivate> tracksGuard(*this);
 
 				if (bgmTracks[0]->stream.queryState() == ALStream::Stopped)
 				{
@@ -237,13 +242,10 @@ struct AudioPrivate
                     for (auto track : bgmTracks)
                         track->setVolume(AudioStream::External, 1.0f);
 					meWatch.state = MeNotPlaying;
-                    for (auto track : bgmTracks)
-                        track->unlockStream();
-
 					break;
 				}
 
-				me.lockStream();
+				std::lock_guard<AudioStream> guard(me);
 
 				if (me.stream.queryState() == ALStream::Playing)
 				{
@@ -251,10 +253,6 @@ struct AudioPrivate
                     for (auto track : bgmTracks)
                         track->extPaused = true;
 					meWatch.state = BgmFadingOut;
-					me.unlockStream();
-                    for (auto track : bgmTracks)
-                        track->unlockStream();
-
 					break;
 				}
 
@@ -270,11 +268,6 @@ struct AudioPrivate
 
                 for (auto track : bgmTracks)
                     track->setVolume(AudioStream::External, vol);
-
-				me.unlockStream();
-                for (auto track : bgmTracks)
-                    track->unlockStream();
-
 				break;
 			}
 			}

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -161,7 +161,7 @@ struct AudioPrivate
                 
                 for (int i = 0; i < (int)(bgmTracks.size()); i++) {
                     AudioStream *track = bgmTracks[i];
-                    bool checkForPlayingTracks = false;
+                    bool checkForPlayingTracks;
 
                     {
                         std::lock_guard<AudioStream> trackGuard(*track);
@@ -169,11 +169,10 @@ struct AudioPrivate
                         float vol = track->getVolume(AudioStream::External);
                         vol -= fadeOutStep;
 
-                        if (vol < 0 || track->stream.queryState() != ALStream::Playing) {
+                        if ((checkForPlayingTracks = vol < 0 || track->stream.queryState() != ALStream::Playing)) {
                             /* Either BGM has fully faded out, or stopped midway. -> MePlaying */
                             track->setVolume(AudioStream::External, 0);
                             track->stream.pause();
-                            checkForPlayingTracks = true;
                         } else {
                             track->setVolume(AudioStream::External, vol);
                         }

--- a/src/audio/audiostream.cpp
+++ b/src/audio/audiostream.cpp
@@ -27,7 +27,7 @@
 #include <SDL_thread.h>
 #include <SDL_timer.h>
 
-#define STREAM_GUARD std::lock_guard<AudioStream> _stream_guard(*this);
+#define STREAM_GUARD std::lock_guard<AudioStream> _stream_guard(*this)
 
 AudioStream::AudioStream(ALStream::LoopMode loopMode,
                          const std::string &threadId)

--- a/src/audio/audiostream.cpp
+++ b/src/audio/audiostream.cpp
@@ -24,9 +24,10 @@
 #include "util.h"
 #include "exception.h"
 
-#include <SDL_mutex.h>
 #include <SDL_thread.h>
 #include <SDL_timer.h>
+
+#define STREAM_GUARD std::lock_guard<AudioStream> _stream_guard(*this);
 
 AudioStream::AudioStream(ALStream::LoopMode loopMode,
                          const std::string &threadId)
@@ -45,8 +46,6 @@ AudioStream::AudioStream(ALStream::LoopMode loopMode,
 
 	fadeIn.thread = 0;
 	fadeIn.threadName = std::string("audio_fadein (") + threadId + ")";
-
-	streamMut = SDL_CreateMutex();
 }
 
 AudioStream::~AudioStream()
@@ -63,14 +62,10 @@ AudioStream::~AudioStream()
 		SDL_WaitThread(fadeIn.thread, 0);
 	}
 
-	lockStream();
+	STREAM_GUARD;
 
 	stream.stop();
 	stream.close();
-
-	unlockStream();
-
-	SDL_DestroyMutex(streamMut);
 }
 
 void AudioStream::play(const std::string &filename,
@@ -80,7 +75,7 @@ void AudioStream::play(const std::string &filename,
 {
 	finiFadeOutInt();
 
-	lockStream();
+	STREAM_GUARD;
 
 	float _volume = clamp<int>(volume, 0, 100) / 100.0f;
 	float _pitch  = clamp<int>(pitch, 50, 150) / 100.0f;
@@ -94,7 +89,6 @@ void AudioStream::play(const std::string &filename,
 	&&  _pitch   == current.pitch
 	&&  (sState == ALStream::Playing || sState == ALStream::Paused))
 	{
-		unlockStream();
 		return;
 	}
 
@@ -106,7 +100,6 @@ void AudioStream::play(const std::string &filename,
 	{
 		setVolume(Base, _volume);
 		current.volume = _volume;
-		unlockStream();
 		return;
 	}
 
@@ -115,17 +108,7 @@ void AudioStream::play(const std::string &filename,
 
 	if (diffFile || sState == ALStream::Closed)
 	{
-		try
-		{
-			/* This will throw on errors while
-			 * opening the data source */
-			stream.open(filename);
-		}
-		catch (const Exception &e)
-		{
-			unlockStream();
-			throw e;
-		}
+		stream.open(filename);
 	} else {
 		switch (sState)
 		{
@@ -152,49 +135,39 @@ void AudioStream::play(const std::string &filename,
 		stream.play(offset);
 	else
 		noResumeStop = false;
-
-	unlockStream();
 }
 
 void AudioStream::stop()
 {
 	finiFadeOutInt();
 
-	lockStream();
+	STREAM_GUARD;
 
 	noResumeStop = true;
 
 	stream.stop();
-
-	unlockStream();
 }
 
 void AudioStream::fadeOut(int duration)
 {
-	lockStream();
+	STREAM_GUARD;
 
 	ALStream::State sState = stream.queryState();
 	noResumeStop = true;
 
 	if (fade.active)
 	{
-		unlockStream();
-
 		return;
 	}
 
 	if (sState == ALStream::Paused)
 	{
 		stream.stop();
-		unlockStream();
-
 		return;
 	}
 
 	if (sState != ALStream::Playing)
 	{
-		unlockStream();
-
 		return;
 	}
 
@@ -213,28 +186,25 @@ void AudioStream::fadeOut(int duration)
 
 	fade.thread = createSDLThread
 		<AudioStream, &AudioStream::fadeOutThread>(this, fade.threadName);
-
-	unlockStream();
 }
 
 void AudioStream::seek(double offset)
 {
-	lockStream();
+	STREAM_GUARD;
 	stream.play(offset);
-	unlockStream();
 }
 
 /* Any access to this classes 'stream' member,
  * whether state query or modification, must be
  * protected by a 'lock'/'unlock' pair */
-void AudioStream::lockStream()
+void AudioStream::lock()
 {
-	SDL_LockMutex(streamMut);
+	streamMut.lock();
 }
 
-void AudioStream::unlockStream()
+void AudioStream::unlock()
 {
-	SDL_UnlockMutex(streamMut);
+	streamMut.unlock();
 }
 
 void AudioStream::setVolume(VolumeType type, float value)
@@ -301,7 +271,7 @@ void AudioStream::fadeOutThread()
 		if (fade.reqTerm)
 			break;
 
-		lockStream();
+		STREAM_GUARD;
 
 		uint32_t curDur = SDL_GetTicks() - fade.startTicks;
 		float resVol = 1.0f - (curDur*fade.msStep);
@@ -316,14 +286,10 @@ void AudioStream::fadeOutThread()
 				stream.stop();
 
 			setVolume(FadeOut, 1.0f);
-			unlockStream();
-
 			break;
 		}
 
 		setVolume(FadeOut, resVol);
-
-		unlockStream();
 
 		SDL_Delay(AUDIO_SLEEP);
 	}
@@ -338,7 +304,7 @@ void AudioStream::fadeInThread()
 		if (fadeIn.rqTerm)
 			break;
 
-		lockStream();
+		STREAM_GUARD;
 
 		/* Fade in duration is always 1 second */
 		uint32_t cur = SDL_GetTicks() - fadeIn.startTicks;
@@ -351,14 +317,10 @@ void AudioStream::fadeInThread()
 		||  fadeIn.rqFini)
 		{
 			setVolume(FadeIn, 1.0f);
-			unlockStream();
-
 			break;
 		}
 
 		setVolume(FadeIn, prog);
-
-		unlockStream();
 
 		SDL_Delay(AUDIO_SLEEP);
 	}

--- a/src/audio/audiostream.h
+++ b/src/audio/audiostream.h
@@ -26,6 +26,7 @@
 #include "alstream.h"
 #include "sdl-util.h"
 
+#include <mutex>
 #include <string>
 
 struct AudioStream
@@ -81,8 +82,10 @@ struct AudioStream
 	bool noResumeStop;
 
 	ALStream stream;
-	SDL_mutex *streamMut;
+private:
+	std::recursive_mutex streamMut;
 
+public:
 	/* Fade out */
 	struct
 	{
@@ -135,8 +138,8 @@ struct AudioStream
 	/* Any access to this classes 'stream' member,
 	 * whether state query or modification, must be
 	 * protected by a 'lock'/'unlock' pair */
-	void lockStream();
-	void unlockStream();
+	void lock();
+	void unlock();
 
 	void setVolume(VolumeType type, float value);
 	float getVolume(VolumeType type);

--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -50,7 +50,6 @@
 #include <SDL_image.h>
 #include <SDL_timer.h>
 #include <SDL_video.h>
-#include <SDL_mutex.h>
 #include <SDL_thread.h>
 
 #ifdef MKXPZ_STEAM
@@ -64,6 +63,7 @@
 #include <time.h>
 #include <cmath>
 #include <climits>
+#include <mutex>
 
 
 #define DEF_SCREEN_W (rgssVer == 1 ? 640 : 544)
@@ -116,7 +116,7 @@ struct Movie
     ALuint audioSource;
     ALuint alBuffers[STREAM_BUFS];
     ALshort audioBuffer[MOVIE_AUDIO_BUFFER_SIZE];
-    SDL_mutex *audioMutex;
+    std::mutex audioMutex;
     
     Movie(bool skippable_)
     : decoder(0), audio(0), video(0), skippable(skippable_), videoBitmap(0), audioThread(0)
@@ -205,14 +205,13 @@ struct Movie
         item->offset = 0;
         item->next = NULL;
         
-        SDL_LockMutex(audioMutex);
+        std::lock_guard<std::mutex> guard(audioMutex);
         if (audioQueueTail) {
             audioQueueTail->next = item;
         } else {
             audioQueueHead = item;
         }
         audioQueueTail = item;
-        SDL_UnlockMutex(audioMutex);
     }
     
     void bufferMovieAudio(THEORAPLAY_Decoder *decoder, const Uint32 now) {
@@ -243,43 +242,45 @@ struct Movie
 
                 remainingSamples = MOVIE_AUDIO_BUFFER_SIZE;
                 sampleBuffer = audioBuffer;
-                SDL_LockMutex(audioMutex);
 
-                while(audioQueueHead && (remainingSamples > 0)) {
-                    audioPacketAndOffset = audioQueueHead;
-                    channels = audioPacketAndOffset->audio->channels;
-                    sampleRate = audioPacketAndOffset->audio->freq;
-                    sourceSamples = audioPacketAndOffset->audio->samples + (audioPacketAndOffset->offset * channels);
-                    samplesToProcess = (audioPacketAndOffset->audio->frames - audioPacketAndOffset->offset) * channels;
 
-                    if (samplesToProcess > remainingSamples) samplesToProcess = remainingSamples;
+                {
+                    std::lock_guard<std::mutex> guard(audioMutex);
 
-                    for (ALuint i = 0; i < samplesToProcess; i++) {
-                        const float val = (*(sourceSamples++));
-                        if (val < -1.0f) {
-                            *(sampleBuffer++) = SHRT_MIN;
-                        } else if (val > 1.0f) {
-                            *(sampleBuffer++) = SHRT_MAX;
-                        } else {
-                            *(sampleBuffer++) = (ALshort) (val * SHRT_MAX);
+                    while(audioQueueHead && (remainingSamples > 0)) {
+                        audioPacketAndOffset = audioQueueHead;
+                        channels = audioPacketAndOffset->audio->channels;
+                        sampleRate = audioPacketAndOffset->audio->freq;
+                        sourceSamples = audioPacketAndOffset->audio->samples + (audioPacketAndOffset->offset * channels);
+                        samplesToProcess = (audioPacketAndOffset->audio->frames - audioPacketAndOffset->offset) * channels;
+
+                        if (samplesToProcess > remainingSamples) samplesToProcess = remainingSamples;
+
+                        for (ALuint i = 0; i < samplesToProcess; i++) {
+                            const float val = (*(sourceSamples++));
+                            if (val < -1.0f) {
+                                *(sampleBuffer++) = SHRT_MIN;
+                            } else if (val > 1.0f) {
+                                *(sampleBuffer++) = SHRT_MAX;
+                            } else {
+                                *(sampleBuffer++) = (ALshort) (val * SHRT_MAX);
+                            }
+                        }
+
+                        // Necessary to remember position between repeated iterations
+                        audioPacketAndOffset->offset += (samplesToProcess / channels);
+                        remainingSamples -= samplesToProcess;
+
+                        // The current audio packet has been completed
+                        if ((audioPacketAndOffset->offset) >= audioPacketAndOffset->audio->frames) {
+                            audioQueueHead = audioPacketAndOffset->next;
+                            THEORAPLAY_freeAudio(audioPacketAndOffset->audio);
+                            free((void *) audioPacketAndOffset);
                         }
                     }
 
-                    // Necessary to remember position between repeated iterations
-                    audioPacketAndOffset->offset += (samplesToProcess / channels);
-                    remainingSamples -= samplesToProcess;
-
-                    // The current audio packet has been completed
-                    if ((audioPacketAndOffset->offset) >= audioPacketAndOffset->audio->frames) {
-                        audioQueueHead = audioPacketAndOffset->next;
-                        THEORAPLAY_freeAudio(audioPacketAndOffset->audio);
-                        free((void *) audioPacketAndOffset);
-                    }
+                    if(!audioQueueHead) audioQueueTail = NULL;
                 }
-
-                if(!audioQueueHead) audioQueueTail = NULL;
-
-                SDL_UnlockMutex(audioMutex);
 
                 alBufferData(alBuffers[procBufs], channels == 1 ? AL_FORMAT_MONO16 : AL_FORMAT_STEREO16, audioBuffer,
                     (MOVIE_AUDIO_BUFFER_SIZE - remainingSamples) * sizeof(ALshort), sampleRate);
@@ -308,7 +309,6 @@ struct Movie
         alSourcef(audioSource, AL_GAIN, volume);
 
         audioThreadTermReq.clear();
-        audioMutex = SDL_CreateMutex();
         queueAudioPacket(audio);
         audio = NULL;
         bufferMovieAudio(decoder, 0);
@@ -406,7 +406,6 @@ struct Movie
                 THEORAPLAY_freeAudio(audioQueueHead->audio);
             }
             audioQueueHead = NULL;
-            SDL_DestroyMutex(audioMutex);
             audioThreadTermReq.set();
             if(audioThread) {
                 SDL_WaitThread(audioThread, 0);
@@ -827,9 +826,9 @@ struct GraphicsPrivate {
     
     std::vector<double> avgFPSData;
     double last_avg_update;
-    SDL_mutex *avgFPSLock;
+    std::mutex avgFPSLock;
     
-    SDL_mutex *glResourceLock;
+    std::recursive_mutex glResourceLock;
     bool multithreadedMode;
     
     /* Global list of all live Disposables
@@ -850,8 +849,6 @@ struct GraphicsPrivate {
     integerScaleActive(rtData->config.integerScaling.active),
     integerLastMileScaling(rtData->config.integerScaling.lastMileScaling) {
         avgFPSData = std::vector<double>();
-        avgFPSLock = SDL_CreateMutex();
-        glResourceLock = SDL_CreateMutex();
         
         if (integerScaleActive) {
             integerScaleFactor = Vec2i(0, 0);
@@ -874,8 +871,6 @@ struct GraphicsPrivate {
     ~GraphicsPrivate() {
         TEXFBO::fini(frozenScene);
         TEXFBO::fini(integerScaleBuffer);
-        SDL_DestroyMutex(avgFPSLock);
-        SDL_DestroyMutex(glResourceLock);
     }
     
     void updateScreenResoRatio(RGSSThreadData *rtData) {
@@ -1129,37 +1124,34 @@ struct GraphicsPrivate {
     
     double averageFPS() {
         double ret = 0;
-        SDL_LockMutex(avgFPSLock);
+        std::lock_guard<std::mutex> guard(avgFPSLock);
         for (double times : avgFPSData)
             ret += times;
         
-        ret = 1 / (ret / avgFPSData.size());
-        SDL_UnlockMutex(avgFPSLock);
-        return ret;
+        return 1 / (ret / avgFPSData.size());
     }
     
     void setLock(bool force = false) {
         if (!(force || multithreadedMode)) return;
         
-        SDL_LockMutex(glResourceLock);
+        glResourceLock.lock();
         SDL_GL_MakeCurrent(threadData->window, threadData->glContext);
     }
     
     void releaseLock(bool force = false) {
         if (!(force || multithreadedMode)) return;
         
-        SDL_UnlockMutex(glResourceLock);
+        glResourceLock.unlock();
     }
 
     void updateAvgFPS() {
-        SDL_LockMutex(avgFPSLock);
+        std::lock_guard<std::mutex> guard(avgFPSLock);
         if (avgFPSData.size() > 40)
             avgFPSData.erase(avgFPSData.begin());
         
         double time = shState->runTime();
         avgFPSData.push_back(time - last_avg_update);
         last_avg_update = time;
-        SDL_UnlockMutex(avgFPSLock);
     }
 };
 

--- a/src/display/graphics.h
+++ b/src/display/graphics.h
@@ -22,6 +22,9 @@
 #ifndef GRAPHICS_H
 #define GRAPHICS_H
 
+#include <mutex>
+
+#include "sharedstate.h"
 #include "util.h"
 
 class Scene;
@@ -111,7 +114,6 @@ private:
 	GraphicsPrivate *p;
 };
 
-#define GFX_LOCK shState->graphics().lock()
-#define GFX_UNLOCK shState->graphics().unlock()
+#define GFX_GUARD std::lock_guard<Graphics> _gfx_guard(shState->graphics())
 
 #endif // GRAPHICS_H

--- a/src/util/disposable.h
+++ b/src/util/disposable.h
@@ -50,16 +50,10 @@ public:
 		if (disposed)
 			return;
 
-		GFX_LOCK;
-		try {
-			releaseResources();
-			disposed = true;
-			wasDisposed();
-		} catch (Exception &e) {
-			GFX_UNLOCK;
-			throw e;
-		}
-		GFX_UNLOCK;
+		GFX_GUARD;
+		releaseResources();
+		disposed = true;
+		wasDisposed();
 	}
 
 	bool isDisposed() const


### PR DESCRIPTION
Locking mutexes manually is error-prone (it's easy to forget to unlock mutexes for every code path or forget to unlock mutexes when an exception is thrown) and increases the complexity of the audio code. We should be using lock guards instead.