### PR TITLE
Implement multithreaded access to the OpenGL state properly

### DIFF
--- a/binding/binding-mri.cpp
+++ b/binding/binding-mri.cpp
@@ -302,7 +302,7 @@ static void mriBindingInit() {
 }
 
 static void showMsg(const std::string &msg) {
-    shState->eThread().showMessageBox(msg.c_str());
+    GFX_GUARD_EXC(shState->eThread().showMessageBox(msg.c_str()););
 }
 
 static void printP(int argc, VALUE *argv, const char *convMethod,

--- a/meson.build
+++ b/meson.build
@@ -113,8 +113,6 @@ if get_option('static_executable') == true
     build_static = true
 endif
 
-global_args += '-DMKXPZ_INIT_GL_LATER'
-
 subdir('src')
 subdir('binding')
 subdir('shader')

--- a/mkxp.json
+++ b/mkxp.json
@@ -300,6 +300,19 @@
     // "integerScalingLastMile": true,
 
 
+    // Select a strategy to use to allow multithreaded access to OpenGL. One of
+    // these will usually result in better performance depending on your
+    // graphics driver.
+    // 0: Attempt to automatically choose the best option
+    // 1: Bind the OpenGL context every time the graphics state is locked, and
+    //    unbind the OpenGL context every time the graphics state is unlocked
+    // 2: Bind the OpenGL context to a proxy thread and proxy all OpenGL calls
+    //    through the proxy thread
+    // (default: 0)
+    //
+    // "multithreadedGl": 0,
+
+
     // Set the base path of the game to '/path/to/game'
     // (default: executable directory)
     //

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -168,6 +168,7 @@ void Config::read(int argc, char *argv[]) {
 #endif
         {"integerScalingActive", false},
         {"integerScalingLastMile", true},
+        {"multithreadedGl", 0},
         {"maxTextureSize", 0},
         {"gameFolder", ""},
         {"anyAltToggleFS", false},
@@ -308,6 +309,7 @@ try { exp } catch (...) {}
     SET_OPT(enableBlitting, boolean);
     SET_OPT_CUSTOMKEY(integerScaling.active, integerScalingActive, boolean);
     SET_OPT_CUSTOMKEY(integerScaling.lastMileScaling, integerScalingLastMile, boolean);
+    SET_OPT(multithreadedGl, integer);
     SET_OPT(maxTextureSize, integer);
     SET_OPT(anyAltToggleFS, boolean);
     SET_OPT(enableReset, boolean);

--- a/src/config.h
+++ b/src/config.h
@@ -77,6 +77,8 @@ struct Config {
         bool lastMileScaling;
     } integerScaling;
     
+    int multithreadedGl;
+    
     std::string gameFolder;
     bool manualFolderSelect;
     

--- a/src/display/gl/gl-fun.cpp
+++ b/src/display/gl/gl-fun.cpp
@@ -25,17 +25,17 @@
 #include "exception.h"
 
 #include <SDL_video.h>
+#include <condition_variable>
+#include <mutex>
 #include <string>
+#include <utility>
 
 GLFunctions gl;
 
 typedef const GLubyte* (APIENTRYP _PFNGLGETSTRINGIPROC) (GLenum, GLuint);
 
-static void parseExtensionsCore(_PFNGLGETINTEGERVPROC GetIntegerv, BoostSet<std::string> &out)
+static void parseExtensionsCore(_PFNGLGETSTRINGIPROC GetStringi, _PFNGLGETINTEGERVPROC GetIntegerv, BoostSet<std::string> &out)
 {
-    _PFNGLGETSTRINGIPROC GetStringi =
-    (_PFNGLGETSTRINGIPROC) SDL_GL_GetProcAddress("glGetStringi");
-    
     GLint extCount = 0;
     GetIntegerv(GL_NUM_EXTENSIONS, &extCount);
     
@@ -68,17 +68,1005 @@ static void parseExtensionsCompat(_PFNGLGETSTRINGPROC GetString, BoostSet<std::s
     }
 }
 
+template <typename Command, typename = void> struct CommandResult
+{
+    static void get(const Command &command) noexcept
+    {
+    }
+    template <typename Function, typename... Args> static void set(const Command &command, Function function, Args... args) noexcept
+    {
+        function(args...);
+    }
+};
+template <typename Command> struct CommandResult<Command, decltype(std::declval<Command>().result, void())>
+{
+    static decltype(std::declval<Command>().result) get(const Command &command) noexcept
+    {
+        return command.result;
+    }
+    template <typename Function, typename... Args> static void set(Command &command, Function function, Args... args) noexcept
+    {
+        command.result = function(args...);
+    }
+};
+
+#define EXECUTE_COMMAND(name, ...) do { \
+    if (!gl.multithreaded && SDL_GL_GetCurrentContext() == nullptr) { \
+        throw Exception(Exception::MKXPError, "Cannot call this function from outside of the graphics thread when Graphics.thread_safe == false"); \
+    } \
+    if (gl.context_release_behavior_none || !gl.multithreaded) { \
+        return gl._impl_##name(__VA_ARGS__); \
+    } \
+    std::unique_lock<std::mutex> guard(gl.mutex); \
+    Command##name command {__VA_ARGS__}; \
+    gl.commandId = command.commandId; \
+    gl.command = &command; \
+    gl.cond.notify_one(); \
+    gl.cond.wait(guard); \
+    return CommandResult<Command##name>::get(command); \
+} while (0)
+
+static constexpr size_t startingCommandId = __COUNTER__;
+
+#define DECLARE_COMMAND_ID static constexpr size_t commandId = (size_t)__COUNTER__ - (size_t)1 - startingCommandId
+
+struct CommandGetError
+{
+    DECLARE_COMMAND_ID;
+    GLenum result;
+};
+static GLenum commandGetError(void)
+{
+    EXECUTE_COMMAND(GetError);
+}
+
+struct CommandClearColor
+{
+    DECLARE_COMMAND_ID;
+    GLclampf red;
+    GLclampf green;
+    GLclampf blue;
+    GLclampf alpha;
+};
+static void commandClearColor(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha)
+{
+    EXECUTE_COMMAND(ClearColor, red, green, blue, alpha);
+}
+
+struct CommandClear
+{
+    DECLARE_COMMAND_ID;
+    GLbitfield mask;
+};
+static void commandClear(GLbitfield mask)
+{
+    EXECUTE_COMMAND(Clear, mask);
+}
+
+struct CommandGetString
+{
+    DECLARE_COMMAND_ID;
+    GLenum name;
+    const GLubyte *result;
+};
+static const GLubyte *commandGetString(GLenum name)
+{
+    EXECUTE_COMMAND(GetString, name);
+}
+
+struct CommandGetStringi
+{
+    DECLARE_COMMAND_ID;
+    GLenum name;
+    GLuint index;
+    const GLubyte *result;
+};
+static const GLubyte *commandGetStringi(GLenum name, GLuint index)
+{
+    EXECUTE_COMMAND(GetStringi, name, index);
+}
+
+struct CommandGetIntegerv
+{
+    DECLARE_COMMAND_ID;
+    GLenum pname;
+    GLint *params;
+};
+static void commandGetIntegerv(GLenum pname, GLint *params)
+{
+    EXECUTE_COMMAND(GetIntegerv, pname, params);
+}
+
+struct CommandPixelStorei
+{
+    DECLARE_COMMAND_ID;
+    GLenum pname;
+    GLint param;
+};
+static void commandPixelStorei(GLenum pname, GLint param)
+{
+    EXECUTE_COMMAND(PixelStorei, pname, param);
+}
+
+struct CommandReadPixels
+{
+    DECLARE_COMMAND_ID;
+    GLint x;
+    GLint y;
+    GLsizei width;
+    GLsizei height;
+    GLenum format;
+    GLenum type;
+    GLvoid *pixels;
+};
+static void commandReadPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLvoid *pixels)
+{
+    EXECUTE_COMMAND(ReadPixels, x, y, width, height, format, type, pixels);
+}
+
+struct CommandEnable
+{
+    DECLARE_COMMAND_ID;
+    GLenum cap;
+};
+static void commandEnable(GLenum cap)
+{
+    EXECUTE_COMMAND(Enable, cap);
+}
+
+struct CommandDisable
+{
+    DECLARE_COMMAND_ID;
+    GLenum cap;
+};
+static void commandDisable(GLenum cap)
+{
+    EXECUTE_COMMAND(Disable, cap);
+}
+
+struct CommandScissor
+{
+    DECLARE_COMMAND_ID;
+    GLint x;
+    GLint y;
+    GLsizei width;
+    GLsizei height;
+};
+static void commandScissor(GLint x, GLint y, GLsizei width, GLsizei height)
+{
+    EXECUTE_COMMAND(Scissor, x, y, width, height);
+}
+
+struct CommandViewport
+{
+    DECLARE_COMMAND_ID;
+    GLint x;
+    GLint y;
+    GLsizei width;
+    GLsizei height;
+};
+static void commandViewport(GLint x, GLint y, GLsizei width, GLsizei height)
+{
+    EXECUTE_COMMAND(Viewport, x, y, width, height);
+}
+
+struct CommandBlendFunc
+{
+    DECLARE_COMMAND_ID;
+    GLenum sfactor;
+    GLenum dfactor;
+};
+static void commandBlendFunc(GLenum sfactor, GLenum dfactor)
+{
+    EXECUTE_COMMAND(BlendFunc, sfactor, dfactor);
+}
+
+struct CommandBlendFuncSeparate
+{
+    DECLARE_COMMAND_ID;
+    GLenum sfactorRGB;
+    GLenum dfactorRGB;
+    GLenum sfactorAlpha;
+    GLenum dfactorAlpha;
+};
+static void commandBlendFuncSeparate(GLenum sfactorRGB, GLenum dfactorRGB, GLenum sfactorAlpha, GLenum dfactorAlpha)
+{
+    EXECUTE_COMMAND(BlendFuncSeparate, sfactorRGB, dfactorRGB, sfactorAlpha, dfactorAlpha);
+}
+
+struct CommandBlendEquation
+{
+    DECLARE_COMMAND_ID;
+    GLenum mode;
+};
+static void commandBlendEquation(GLenum mode)
+{
+    EXECUTE_COMMAND(BlendEquation, mode);
+}
+
+struct CommandDrawElements
+{
+    DECLARE_COMMAND_ID;
+    GLenum mode;
+    GLsizei count;
+    GLenum type;
+    const GLvoid *indices;
+};
+static void commandDrawElements(GLenum mode, GLsizei count, GLenum type, const GLvoid *indices)
+{
+    EXECUTE_COMMAND(DrawElements, mode, count, type, indices);
+}
+
+struct CommandGenTextures
+{
+    DECLARE_COMMAND_ID;
+    GLsizei n;
+    GLuint *textures;
+};
+static void commandGenTextures(GLsizei n, GLuint *textures)
+{
+    EXECUTE_COMMAND(GenTextures, n, textures);
+}
+
+struct CommandDeleteTextures
+{
+    DECLARE_COMMAND_ID;
+    GLsizei n;
+    const GLuint *textures;
+};
+static void commandDeleteTextures(GLsizei n, const GLuint *textures)
+{
+    EXECUTE_COMMAND(DeleteTextures, n, textures);
+}
+
+struct CommandBindTexture
+{
+    DECLARE_COMMAND_ID;
+    GLenum target;
+    GLuint texture;
+};
+static void commandBindTexture(GLenum target, GLuint texture)
+{
+    EXECUTE_COMMAND(BindTexture, target, texture);
+}
+
+struct CommandTexImage2D
+{
+    DECLARE_COMMAND_ID;
+    GLenum target;
+    GLint level;
+    GLint internalformat;
+    GLsizei width;
+    GLsizei height;
+    GLint border;
+    GLenum format;
+    GLenum type;
+    const GLvoid *pixels;
+};
+static void commandTexImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid *pixels)
+{
+    EXECUTE_COMMAND(TexImage2D, target, level, internalformat, width, height, border, format, type, pixels);
+}
+
+struct CommandTexSubImage2D
+{
+    DECLARE_COMMAND_ID;
+    GLenum target;
+    GLint level;
+    GLint xoffset;
+    GLint yoffset;
+    GLsizei width;
+    GLsizei height;
+    GLenum format;
+    GLenum type;
+    const GLvoid *pixels;
+};
+static void commandTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const GLvoid *pixels)
+{
+    EXECUTE_COMMAND(TexSubImage2D, target, level, xoffset, yoffset, width, height, format, type, pixels);
+}
+
+struct CommandTexParameteri
+{
+    DECLARE_COMMAND_ID;
+    GLenum target;
+    GLenum pname;
+    GLint param;
+};
+static void commandTexParameteri(GLenum target, GLenum pname, GLint param)
+{
+    EXECUTE_COMMAND(TexParameteri, target, pname, param);
+}
+
+struct CommandActiveTexture
+{
+    DECLARE_COMMAND_ID;
+    GLenum texture;
+};
+static void commandActiveTexture(GLenum texture)
+{
+    EXECUTE_COMMAND(ActiveTexture, texture);
+}
+
+
+struct CommandGenerateMipmap
+{
+    DECLARE_COMMAND_ID;
+    GLenum target;
+};
+static void commandGenerateMipmap(GLenum target)
+{
+    EXECUTE_COMMAND(GenerateMipmap, target);
+}
+
+struct CommandGenerateTextureMipmap
+{
+    DECLARE_COMMAND_ID;
+    GLuint texture;
+};
+static void commandGenerateTextureMipmap(GLuint texture)
+{
+    EXECUTE_COMMAND(GenerateTextureMipmap, texture);
+}
+
+struct CommandDebugMessageCallback
+{
+    DECLARE_COMMAND_ID;
+    _GLDEBUGPROC callback;
+    const void *userParam;
+};
+static void commandDebugMessageCallback(_GLDEBUGPROC callback, const void *userParam)
+{
+    EXECUTE_COMMAND(DebugMessageCallback, callback, userParam);
+}
+
+struct CommandStringMarker
+{
+    DECLARE_COMMAND_ID;
+    GLsizei len;
+    const GLvoid *string;
+};
+static void commandStringMarker(GLsizei len, const GLvoid *string)
+{
+    EXECUTE_COMMAND(StringMarker, len, string);
+}
+
+struct CommandGenBuffers
+{
+    DECLARE_COMMAND_ID;
+    GLsizei n;
+    GLuint *buffers;
+};
+static void commandGenBuffers(GLsizei n, GLuint *buffers)
+{
+    EXECUTE_COMMAND(GenBuffers, n, buffers);
+}
+
+struct CommandDeleteBuffers
+{
+    DECLARE_COMMAND_ID;
+    GLsizei n;
+    const GLuint *buffers;
+};
+static void commandDeleteBuffers(GLsizei n, const GLuint *buffers)
+{
+    EXECUTE_COMMAND(DeleteBuffers, n, buffers);
+}
+
+struct CommandBindBuffer
+{
+    DECLARE_COMMAND_ID;
+    GLenum target;
+    GLuint buffer;
+};
+static void commandBindBuffer(GLenum target, GLuint buffer)
+{
+    EXECUTE_COMMAND(BindBuffer, target, buffer);
+}
+
+struct CommandBufferData
+{
+    DECLARE_COMMAND_ID;
+    GLenum target;
+    GLsizeiptr size;
+    const GLvoid *data;
+    GLenum usage;
+};
+static void commandBufferData(GLenum target, GLsizeiptr size, const GLvoid *data, GLenum usage)
+{
+    EXECUTE_COMMAND(BufferData, target, size, data, usage);
+}
+
+struct CommandBufferSubData
+{
+    DECLARE_COMMAND_ID;
+    GLenum target;
+    GLintptr offset;
+    GLsizeiptr size;
+    const GLvoid *data;
+};
+static void commandBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, const GLvoid *data)
+{
+    EXECUTE_COMMAND(BufferSubData, target, offset, size, data);
+}
+
+struct CommandCreateShader
+{
+    DECLARE_COMMAND_ID;
+    GLenum type;
+    GLuint result;
+};
+static GLuint commandCreateShader(GLenum type)
+{
+    EXECUTE_COMMAND(CreateShader, type);
+}
+
+struct CommandDeleteShader
+{
+    DECLARE_COMMAND_ID;
+    GLuint shader;
+};
+static void commandDeleteShader(GLuint shader)
+{
+    EXECUTE_COMMAND(DeleteShader, shader);
+}
+
+struct CommandShaderSource
+{
+    DECLARE_COMMAND_ID;
+    GLuint shader;
+    GLsizei count;
+    const GLchar *const *strings;
+    const GLint *lengths;
+};
+static void commandShaderSource(GLuint shader, GLsizei count, const GLchar *const *strings, const GLint *lengths)
+{
+    EXECUTE_COMMAND(ShaderSource, shader, count, strings, lengths);
+}
+
+struct CommandCompileShader
+{
+    DECLARE_COMMAND_ID;
+    GLuint shader;
+};
+static void commandCompileShader(GLuint shader)
+{
+    EXECUTE_COMMAND(CompileShader, shader);
+}
+
+struct CommandAttachShader
+{
+    DECLARE_COMMAND_ID;
+    GLuint program;
+    GLuint shader;
+};
+static void commandAttachShader(GLuint program, GLuint shader)
+{
+    EXECUTE_COMMAND(AttachShader, program, shader);
+}
+
+struct CommandGetShaderiv
+{
+    DECLARE_COMMAND_ID;
+    GLuint shader;
+    GLenum pname;
+    GLint *param;
+};
+static void commandGetShaderiv(GLuint shader, GLenum pname, GLint *param)
+{
+    EXECUTE_COMMAND(GetShaderiv, shader, pname, param);
+}
+
+struct CommandGetShaderInfoLog
+{
+    DECLARE_COMMAND_ID;
+    GLuint shader;
+    GLsizei bufSize;
+    GLsizei *length;
+    GLchar *infoLog;
+};
+static void commandGetShaderInfoLog(GLuint shader, GLsizei bufSize, GLsizei *length, GLchar *infoLog)
+{
+    EXECUTE_COMMAND(GetShaderInfoLog, shader, bufSize, length, infoLog);
+}
+
+
+struct CommandCreateProgram
+{
+    DECLARE_COMMAND_ID;
+    GLuint result;
+};
+static GLuint commandCreateProgram(void)
+{
+    EXECUTE_COMMAND(CreateProgram);
+}
+
+struct CommandDeleteProgram
+{
+    DECLARE_COMMAND_ID;
+    GLuint program;
+};
+static void commandDeleteProgram(GLuint program)
+{
+    EXECUTE_COMMAND(DeleteProgram, program);
+}
+
+struct CommandUseProgram
+{
+    DECLARE_COMMAND_ID;
+    GLuint program;
+};
+static void commandUseProgram(GLuint program)
+{
+    EXECUTE_COMMAND(UseProgram, program);
+}
+
+struct CommandLinkProgram
+{
+    DECLARE_COMMAND_ID;
+    GLuint program;
+};
+static void commandLinkProgram(GLuint program)
+{
+    EXECUTE_COMMAND(LinkProgram, program);
+}
+
+struct CommandGetProgramiv
+{
+    DECLARE_COMMAND_ID;
+    GLuint program;
+    GLenum pname;
+    GLint *param;
+};
+static void commandGetProgramiv(GLuint program, GLenum pname, GLint *param)
+{
+    EXECUTE_COMMAND(GetProgramiv, program, pname, param);
+}
+
+struct CommandGetProgramInfoLog
+{
+    DECLARE_COMMAND_ID;
+    GLuint program;
+    GLsizei bufSize;
+    GLsizei *length;
+    GLchar *infoLog;
+};
+static void commandGetProgramInfoLog(GLuint program, GLsizei bufSize, GLsizei *length, GLchar *infoLog)
+{
+    EXECUTE_COMMAND(GetProgramInfoLog, program, bufSize, length, infoLog);
+}
+
+struct CommandGetUniformLocation
+{
+    DECLARE_COMMAND_ID;
+    GLuint program;
+    const GLchar *name;
+    GLint result;
+};
+static GLint commandGetUniformLocation(GLuint program, const GLchar *name)
+{
+    EXECUTE_COMMAND(GetUniformLocation, program, name);
+}
+
+struct CommandUniform1f
+{
+    DECLARE_COMMAND_ID;
+    GLint location;
+    GLfloat v0;
+};
+static void commandUniform1f(GLint location, GLfloat v0)
+{
+    EXECUTE_COMMAND(Uniform1f, location, v0);
+}
+
+struct CommandUniform2f
+{
+    DECLARE_COMMAND_ID;
+    GLint location;
+    GLfloat v0;
+    GLfloat v1;
+};
+static void commandUniform2f(GLint location, GLfloat v0, GLfloat v1)
+{
+    EXECUTE_COMMAND(Uniform2f, location, v0, v1);
+}
+
+struct CommandUniform4f
+{
+    DECLARE_COMMAND_ID;
+    GLint location;
+    GLfloat v0;
+    GLfloat v1;
+    GLfloat v2;
+    GLfloat v3;
+};
+static void commandUniform4f(GLint location, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3)
+{
+    EXECUTE_COMMAND(Uniform4f, location, v0, v1, v2, v3);
+}
+
+struct CommandUniform1i
+{
+    DECLARE_COMMAND_ID;
+    GLint location;
+    GLint v0;
+};
+static void commandUniform1i(GLint location, GLint v0)
+{
+    EXECUTE_COMMAND(Uniform1i, location, v0);
+}
+
+struct CommandUniform1iv
+{
+    DECLARE_COMMAND_ID;
+    GLint location;
+    GLsizei count;
+    const GLint *value;
+};
+static void commandUniform1iv(GLint location, GLsizei count, const GLint *value)
+{
+    EXECUTE_COMMAND(Uniform1iv, location, count, value);
+}
+
+struct CommandUniformMatrix4fv
+{
+    DECLARE_COMMAND_ID;
+    GLint location;
+    GLsizei count;
+    GLboolean transpose;
+    const GLfloat *value;
+};
+static void commandUniformMatrix4fv(GLint location, GLsizei count, GLboolean transpose, const GLfloat *value)
+{
+    EXECUTE_COMMAND(UniformMatrix4fv, location, count, transpose, value);
+}
+
+struct CommandBindAttribLocation
+{
+    DECLARE_COMMAND_ID;
+    GLuint program;
+    GLuint index;
+    const GLchar *name;
+};
+static void commandBindAttribLocation(GLuint program, GLuint index, const GLchar *name)
+{
+    EXECUTE_COMMAND(BindAttribLocation, program, index, name);
+}
+
+struct CommandEnableVertexAttribArray
+{
+    DECLARE_COMMAND_ID;
+    GLuint index;
+};
+static void commandEnableVertexAttribArray(GLuint index)
+{
+    EXECUTE_COMMAND(EnableVertexAttribArray, index);
+}
+
+struct CommandDisableVertexAttribArray
+{
+    DECLARE_COMMAND_ID;
+    GLuint index;
+};
+static void commandDisableVertexAttribArray(GLuint index)
+{
+    EXECUTE_COMMAND(DisableVertexAttribArray, index);
+}
+
+struct CommandVertexAttribPointer
+{
+    DECLARE_COMMAND_ID;
+    GLuint index;
+    GLint size;
+    GLenum type;
+    GLboolean normalized;
+    GLsizei stride;
+    const GLvoid *pointer;
+};
+static void commandVertexAttribPointer(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid *pointer)
+{
+    EXECUTE_COMMAND(VertexAttribPointer, index, size, type, normalized, stride, pointer);
+}
+
+struct CommandGenFramebuffers
+{
+    DECLARE_COMMAND_ID;
+    GLsizei n;
+    GLuint *framebuffers;
+};
+static void commandGenFramebuffers(GLsizei n, GLuint *framebuffers)
+{
+    EXECUTE_COMMAND(GenFramebuffers, n, framebuffers);
+}
+
+struct CommandDeleteFramebuffers
+{
+    DECLARE_COMMAND_ID;
+    GLsizei n;
+    const GLuint *framebuffers;
+};
+static void commandDeleteFramebuffers(GLsizei n, const GLuint *framebuffers)
+{
+    EXECUTE_COMMAND(DeleteFramebuffers, n, framebuffers);
+}
+
+struct CommandBindFramebuffer
+{
+    DECLARE_COMMAND_ID;
+    GLenum target;
+    GLuint framebuffer;
+};
+static void commandBindFramebuffer(GLenum target, GLuint framebuffer)
+{
+    EXECUTE_COMMAND(BindFramebuffer, target, framebuffer);
+}
+
+struct CommandFramebufferTexture2D
+{
+    DECLARE_COMMAND_ID;
+    GLenum target;
+    GLenum attachment;
+    GLenum textarget;
+    GLuint texture;
+    GLint level;
+};
+static void commandFramebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level)
+{
+    EXECUTE_COMMAND(FramebufferTexture2D, target, attachment, textarget, texture, level);
+}
+
+struct CommandBlitFramebuffer
+{
+    DECLARE_COMMAND_ID;
+    GLint srcX0;
+    GLint srcY0;
+    GLint srcX1;
+    GLint srcY1;
+    GLint dstX0;
+    GLint dstY0;
+    GLint dstX1;
+    GLint dstY1;
+    GLbitfield mask;
+    GLenum filter;
+};
+static void commandBlitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter)
+{
+    EXECUTE_COMMAND(BlitFramebuffer, srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+}
+
+struct CommandGenVertexArrays
+{
+    DECLARE_COMMAND_ID;
+    GLsizei n;
+    GLuint *arrays;
+};
+static void commandGenVertexArrays(GLsizei n, GLuint *arrays)
+{
+    EXECUTE_COMMAND(GenVertexArrays, n, arrays);
+}
+
+struct CommandDeleteVertexArrays
+{
+    DECLARE_COMMAND_ID;
+    GLsizei n;
+    const GLuint *arrays;
+};
+static void commandDeleteVertexArrays(GLsizei n, const GLuint *arrays)
+{
+    EXECUTE_COMMAND(DeleteVertexArrays, n, arrays);
+}
+
+struct CommandBindVertexArray
+{
+    DECLARE_COMMAND_ID;
+    GLuint array;
+};
+static void commandBindVertexArray(GLuint array)
+{
+    EXECUTE_COMMAND(BindVertexArray, array);
+}
+
+struct CommandReleaseShaderCompiler
+{
+    DECLARE_COMMAND_ID;
+};
+static void commandReleaseShaderCompiler(void)
+{
+    EXECUTE_COMMAND(ReleaseShaderCompiler);
+}
+
+struct CommandMakeCurrent
+{
+    DECLARE_COMMAND_ID;
+    SDL_Window *window;
+    SDL_GLContext context;
+    const char *result;
+};
+static const char *commandMakeCurrent(SDL_Window *window, SDL_GLContext context)
+{
+    EXECUTE_COMMAND(MakeCurrent, window, context);
+}
+
+struct CommandSetSwapInterval
+{
+    DECLARE_COMMAND_ID;
+    int interval;
+    int result;
+};
+static int commandSetSwapInterval(int interval)
+{
+    EXECUTE_COMMAND(SetSwapInterval, interval);
+}
+
+struct CommandGetSwapInterval
+{
+    DECLARE_COMMAND_ID;
+    int result;
+};
+static int commandGetSwapInterval(void)
+{
+    EXECUTE_COMMAND(GetSwapInterval);
+}
+
+struct CommandSwapWindow
+{
+    DECLARE_COMMAND_ID;
+    SDL_Window *window;
+};
+static void commandSwapWindow(SDL_Window *window)
+{
+    EXECUTE_COMMAND(SwapWindow, window);
+}
+
 #define GL_FUN(name, type) \
-gl.name = (type) SDL_GL_GetProcAddress("gl" #name EXT_SUFFIX);
+    gl.name = (gl._impl_##name = (type) SDL_GL_GetProcAddress("gl" #name EXT_SUFFIX)) == nullptr ? nullptr : command##name;
 
 #define EXC(msg) \
 Exception(Exception::MKXPError, "%s", msg)
 
-void initGLFunctions()
+#define DEF_COMMAND_HANDLER(name, ...) []() { \
+    static_assert(Command##name::commandId == (size_t)__COUNTER__ - (size_t)1 - startingCommandHandlerId, "command handlers need to be defined in the same order as the command commands themselves"); \
+    Command##name &command = *(Command##name *)gl.command; \
+    CommandResult<Command##name>::set(command, gl._impl_##name, __VA_ARGS__); \
+}
+
+#define DEF_COMMAND_HANDLER_NO_ARGS(name) []() { \
+    static_assert(Command##name::commandId == (size_t)__COUNTER__ - (size_t)1 - startingCommandHandlerId, "command handlers need to be defined in the same order as the command commands themselves"); \
+    Command##name &command = *(Command##name *)gl.command; \
+    CommandResult<Command##name>::set(command, gl._impl_##name); \
+}
+
+int glThreadFun(void *userdata)
+{
+    static constexpr size_t startingCommandHandlerId = __COUNTER__;
+    static void (*const handlers[])(void) = {
+        DEF_COMMAND_HANDLER_NO_ARGS(GetError),
+        DEF_COMMAND_HANDLER(ClearColor, command.red, command.green, command.blue, command.alpha),
+        DEF_COMMAND_HANDLER(Clear, command.mask),
+        DEF_COMMAND_HANDLER(GetString, command.name),
+        DEF_COMMAND_HANDLER(GetStringi, command.name, command.index),
+        DEF_COMMAND_HANDLER(GetIntegerv, command.pname, command.params),
+        DEF_COMMAND_HANDLER(PixelStorei, command.pname, command.param),
+        DEF_COMMAND_HANDLER(ReadPixels, command.x, command.y, command.width, command.height, command.format, command.type, command.pixels),
+        DEF_COMMAND_HANDLER(Enable, command.cap),
+        DEF_COMMAND_HANDLER(Disable, command.cap),
+        DEF_COMMAND_HANDLER(Scissor, command.x, command.y, command.width, command.height),
+        DEF_COMMAND_HANDLER(Viewport, command.x, command.y, command.width, command.height),
+        DEF_COMMAND_HANDLER(BlendFunc, command.sfactor, command.dfactor),
+        DEF_COMMAND_HANDLER(BlendFuncSeparate, command.sfactorRGB, command.dfactorRGB, command.sfactorAlpha, command.dfactorAlpha),
+        DEF_COMMAND_HANDLER(BlendEquation, command.mode),
+        DEF_COMMAND_HANDLER(DrawElements, command.mode, command.count, command.type, command.indices),
+        DEF_COMMAND_HANDLER(GenTextures, command.n, command.textures),
+        DEF_COMMAND_HANDLER(DeleteTextures, command.n, command.textures),
+        DEF_COMMAND_HANDLER(BindTexture, command.target, command.texture),
+        DEF_COMMAND_HANDLER(TexImage2D, command.target, command.level, command.internalformat, command.width, command.height, command.border, command.format, command.type, command.pixels),
+        DEF_COMMAND_HANDLER(TexSubImage2D, command.target, command.level, command.xoffset, command.yoffset, command.width, command.height, command.format, command.type, command.pixels),
+        DEF_COMMAND_HANDLER(TexParameteri, command.target, command.pname, command.param),
+        DEF_COMMAND_HANDLER(ActiveTexture, command.texture),
+        DEF_COMMAND_HANDLER(GenerateMipmap, command.target),
+        DEF_COMMAND_HANDLER(GenerateTextureMipmap, command.texture),
+        DEF_COMMAND_HANDLER(DebugMessageCallback, command.callback, command.userParam),
+        DEF_COMMAND_HANDLER(StringMarker, command.len, command.string),
+        DEF_COMMAND_HANDLER(GenBuffers, command.n, command.buffers),
+        DEF_COMMAND_HANDLER(DeleteBuffers, command.n, command.buffers),
+        DEF_COMMAND_HANDLER(BindBuffer, command.target, command.buffer),
+        DEF_COMMAND_HANDLER(BufferData, command.target, command.size, command.data, command.usage),
+        DEF_COMMAND_HANDLER(BufferSubData, command.target, command.offset, command.size, command.data),
+        DEF_COMMAND_HANDLER(CreateShader, command.type),
+        DEF_COMMAND_HANDLER(DeleteShader, command.shader),
+        DEF_COMMAND_HANDLER(ShaderSource, command.shader, command.count, command.strings, command.lengths),
+        DEF_COMMAND_HANDLER(CompileShader, command.shader),
+        DEF_COMMAND_HANDLER(AttachShader, command.program, command.shader),
+        DEF_COMMAND_HANDLER(GetShaderiv, command.shader, command.pname, command.param),
+        DEF_COMMAND_HANDLER(GetShaderInfoLog, command.shader, command.bufSize, command.length, command.infoLog),
+        DEF_COMMAND_HANDLER_NO_ARGS(CreateProgram),
+        DEF_COMMAND_HANDLER(DeleteProgram, command.program),
+        DEF_COMMAND_HANDLER(UseProgram, command.program),
+        DEF_COMMAND_HANDLER(LinkProgram, command.program),
+        DEF_COMMAND_HANDLER(GetProgramiv, command.program, command.pname, command.param),
+        DEF_COMMAND_HANDLER(GetProgramInfoLog, command.program, command.bufSize, command.length, command.infoLog),
+        DEF_COMMAND_HANDLER(GetUniformLocation, command.program, command.name),
+        DEF_COMMAND_HANDLER(Uniform1f, command.location, command.v0),
+        DEF_COMMAND_HANDLER(Uniform2f, command.location, command.v0, command.v1),
+        DEF_COMMAND_HANDLER(Uniform4f, command.location, command.v0, command.v1, command.v2, command.v3),
+        DEF_COMMAND_HANDLER(Uniform1i, command.location, command.v0),
+        DEF_COMMAND_HANDLER(Uniform1iv, command.location, command.count, command.value),
+        DEF_COMMAND_HANDLER(UniformMatrix4fv, command.location, command.count, command.transpose, command.value),
+        DEF_COMMAND_HANDLER(BindAttribLocation, command.program, command.index, command.name),
+        DEF_COMMAND_HANDLER(EnableVertexAttribArray, command.index),
+        DEF_COMMAND_HANDLER(DisableVertexAttribArray, command.index),
+        DEF_COMMAND_HANDLER(VertexAttribPointer, command.index, command.size, command.type, command.normalized, command.stride, command.pointer),
+        DEF_COMMAND_HANDLER(GenFramebuffers, command.n, command.framebuffers),
+        DEF_COMMAND_HANDLER(DeleteFramebuffers, command.n, command.framebuffers),
+        DEF_COMMAND_HANDLER(BindFramebuffer, command.target, command.framebuffer),
+        DEF_COMMAND_HANDLER(FramebufferTexture2D, command.target, command.attachment, command.textarget, command.texture, command.level),
+        DEF_COMMAND_HANDLER(BlitFramebuffer, command.srcX0, command.srcY0, command.srcX1, command.srcY1, command.dstX0, command.dstY0, command.dstX1, command.dstY1, command.mask, command.filter),
+        DEF_COMMAND_HANDLER(GenVertexArrays, command.n, command.arrays),
+        DEF_COMMAND_HANDLER(DeleteVertexArrays, command.n, command.arrays),
+        DEF_COMMAND_HANDLER(BindVertexArray, command.array),
+        DEF_COMMAND_HANDLER_NO_ARGS(ReleaseShaderCompiler),
+        DEF_COMMAND_HANDLER(MakeCurrent, command.window, command.context),
+        DEF_COMMAND_HANDLER(SetSwapInterval, command.interval),
+        DEF_COMMAND_HANDLER_NO_ARGS(GetSwapInterval),
+        DEF_COMMAND_HANDLER(SwapWindow, command.window),
+    };
+    std::unique_lock<std::mutex> guard(gl.mutex);
+    gl.cond.notify_one();
+    for (;;) {
+        gl.cond.wait(guard);
+        if (gl.commandId >= sizeof handlers / sizeof *handlers) {
+            return 0;
+        }
+        handlers[gl.commandId]();
+        gl.cond.notify_one();
+    }
+    return 0;
+}
+
+void initGLFunctions(SDL_Window *window, SDL_GLContext context)
 {
 #define EXT_SUFFIX ""
     GL_20_FUN;
-    
+    gl.MakeCurrent = commandMakeCurrent;
+    gl._impl_MakeCurrent = [](SDL_Window *window, SDL_GLContext context) {
+        return SDL_GL_MakeCurrent(window, context) < 0 ? SDL_GetError() : nullptr;
+    };
+    gl.SetSwapInterval = commandSetSwapInterval;
+    gl._impl_SetSwapInterval = SDL_GL_SetSwapInterval;
+    gl.GetSwapInterval = commandGetSwapInterval;
+    gl._impl_GetSwapInterval = SDL_GL_GetSwapInterval;
+    gl.SwapWindow = commandSwapWindow;
+    gl._impl_SwapWindow = SDL_GL_SwapWindow;
+
+    gl.multithreaded = true;
+
+    {
+        GLint context_release_behavior = GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH;
+        gl._impl_GetIntegerv(GL_CONTEXT_RELEASE_BEHAVIOR, &context_release_behavior);
+        gl.context_release_behavior_none = context_release_behavior == GL_NONE;
+    }
+
+    if (gl.context_release_behavior_none) {
+        gl.thread = nullptr;
+    } else {
+        if (gl.multithreaded && SDL_GL_MakeCurrent(window, nullptr) < 0) {
+            throw Exception(Exception::MKXPError, "Could not unbind OpenGL context: %s", SDL_GetError());
+        }
+        {
+            std::unique_lock<std::mutex> guard(gl.mutex);
+            if ((gl.thread = SDL_CreateThread(glThreadFun, "gl", nullptr)) == nullptr) {
+                throw Exception(Exception::MKXPError, "Could not create OpenGL thread: %s", SDL_GetError());
+            }
+            gl.cond.wait(guard);
+        }
+        if (gl.multithreaded) {
+            const char *error = gl.MakeCurrent(window, context);
+            if (error != nullptr) {
+                throw Exception(Exception::MKXPError, "Could not bind OpenGL context on the OpenGL thread: %s", SDL_GetError());
+            }
+        }
+    }
+
     /* Determine GL version */
     const char *ver = (const char*) gl.GetString(GL_VERSION);
     
@@ -123,7 +1111,7 @@ void initGLFunctions()
     BoostSet<std::string> ext;
     
     if (glMajor >= 3)
-        parseExtensionsCore(gl.GetIntegerv, ext);
+        parseExtensionsCore(gl.GetStringi, gl.GetIntegerv, ext);
     else
         parseExtensionsCompat(gl.GetString, ext);
     

--- a/src/display/gl/gl-fun.cpp
+++ b/src/display/gl/gl-fun.cpp
@@ -933,13 +933,13 @@ static void commandSwapWindow(SDL_Window *window)
 Exception(Exception::MKXPError, "%s", msg)
 
 #define DEF_COMMAND_HANDLER(name, ...) []() { \
-    static_assert(Command##name::commandId == (size_t)__COUNTER__ - startingCommandHandlerId, "command handlers need to be defined in the same order as the command commands themselves"); \
+    static_assert(Command##name::commandId == (size_t)__COUNTER__ - startingCommandHandlerId, "command handlers need to be defined in the same order as the commands themselves"); \
     Command##name &command = *(Command##name *)gl.command; \
     CommandResult<Command##name>::set(command, gl._impl_##name, __VA_ARGS__); \
 }
 
 #define DEF_COMMAND_HANDLER_NO_ARGS(name) []() { \
-    static_assert(Command##name::commandId == (size_t)__COUNTER__ - startingCommandHandlerId, "command handlers need to be defined in the same order as the command commands themselves"); \
+    static_assert(Command##name::commandId == (size_t)__COUNTER__ - startingCommandHandlerId, "command handlers need to be defined in the same order as the commands themselves"); \
     Command##name &command = *(Command##name *)gl.command; \
     CommandResult<Command##name>::set(command, gl._impl_##name); \
 }

--- a/src/display/gl/gl-fun.cpp
+++ b/src/display/gl/gl-fun.cpp
@@ -70,7 +70,7 @@ template <typename Command, typename = void> struct CommandResult
     static void get(const Command &command) noexcept
     {
     }
-    template <typename Function, typename... Args> static void set(const Command &command, Function function, Args... args) noexcept
+    template <typename Function, typename... Args> static void set(Command &command, Function function, Args... args) noexcept
     {
         function(args...);
     }

--- a/src/display/gl/gl-fun.cpp
+++ b/src/display/gl/gl-fun.cpp
@@ -1055,11 +1055,19 @@ void initGLFunctions(SDL_Window *window, SDL_GLContext context)
 
     gl.multithreaded = true;
 
+#ifdef __APPLE__
+    /* ANGLE doesn't support KHR_context_flush_control but doesn't flush the OpenGL pipeline when the context is bound/unbound,
+     * so consider the release behavior to be GL_NONE when using ANGLE on any platform.
+     * Core OpenGL (CGL) also neither supports KHR_context_flush_control nor flushes the pipeline on context binding/unbinding,
+     * so also consider the release behavior to be GL_NONE on Apple platforms when ANGLE is not being used. */
+    gl.context_release_behavior_none = true;
+#else
     {
         GLint context_release_behavior = 0x82fc /* GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH */;
         gl._impl_GetIntegerv(0x82fb /* GL_CONTEXT_RELEASE_BEHAVIOR */, &context_release_behavior);
         gl.context_release_behavior_none = context_release_behavior == GL_NONE;
     }
+#endif
 
     if (gl.context_release_behavior_none) {
         gl.thread = nullptr;

--- a/src/display/gl/gl-fun.cpp
+++ b/src/display/gl/gl-fun.cpp
@@ -99,9 +99,9 @@ template <typename Command> struct CommandResult<Command, decltype(std::declval<
     gl.commandId = command.commandId; \
     gl.command = &command; \
     gl.cond.notify_one(); \
-    while (gl.commandId != 0) { \
+    do { \
         gl.cond.wait(guard); \
-    } \
+    } while (gl.commandId != 0); \
     return CommandResult<Command##name>::get(command); \
 } while (0)
 
@@ -1023,9 +1023,9 @@ int glThreadFun(void *userdata)
     gl.commandId = 0;
     gl.cond.notify_one();
     for (;;) {
-        while (gl.commandId == 0) {
+        do {
             gl.cond.wait(guard);
-        }
+        } while (gl.commandId == 0);
         if (gl.commandId > sizeof handlers / sizeof *handlers) {
             return 0;
         }
@@ -1073,9 +1073,9 @@ void initGLFunctions(SDL_Window *window, SDL_GLContext context)
             if ((gl.thread = SDL_CreateThread(glThreadFun, "gl", nullptr)) == nullptr) {
                 throw Exception(Exception::MKXPError, "Could not create OpenGL thread: %s", SDL_GetError());
             }
-            while (gl.commandId != 0) {
+            do {
                 gl.cond.wait(guard);
-            }
+            } while (gl.commandId != 0);
         }
         if (gl.multithreaded) {
             const char *error = gl.MakeCurrent(window, context);

--- a/src/display/gl/gl-fun.cpp
+++ b/src/display/gl/gl-fun.cpp
@@ -870,6 +870,17 @@ static void commandReleaseShaderCompiler(void)
     EXECUTE_COMMAND(ReleaseShaderCompiler);
 }
 
+struct CommandGetProcAddress
+{
+    DECLARE_COMMAND_ID;
+    const char *proc;
+    void *result;
+};
+static void *commandGetProcAddress(const char *proc)
+{
+    EXECUTE_COMMAND(GetProcAddress, proc);
+}
+
 struct CommandMakeCurrent
 {
     DECLARE_COMMAND_ID;
@@ -914,7 +925,7 @@ static void commandSwapWindow(SDL_Window *window)
 }
 
 #define GL_FUN(name, type) \
-    gl.name = (gl._impl_##name = (type) SDL_GL_GetProcAddress("gl" #name EXT_SUFFIX)) == nullptr ? nullptr : command##name;
+    gl.name = (gl._impl_##name = (type)gl.GetProcAddress("gl" #name EXT_SUFFIX)) == nullptr ? nullptr : command##name;
 
 #define EXC(msg) \
 Exception(Exception::MKXPError, "%s", msg)
@@ -1000,6 +1011,7 @@ int glThreadFun(void *userdata)
         DEF_COMMAND_HANDLER(DeleteVertexArrays, command.n, command.arrays),
         DEF_COMMAND_HANDLER(BindVertexArray, command.array),
         DEF_COMMAND_HANDLER_NO_ARGS(ReleaseShaderCompiler),
+        DEF_COMMAND_HANDLER(GetProcAddress, command.proc),
         DEF_COMMAND_HANDLER(MakeCurrent, command.window, command.context),
         DEF_COMMAND_HANDLER(SetSwapInterval, command.interval),
         DEF_COMMAND_HANDLER_NO_ARGS(GetSwapInterval),
@@ -1020,8 +1032,7 @@ int glThreadFun(void *userdata)
 
 void initGLFunctions(SDL_Window *window, SDL_GLContext context)
 {
-#define EXT_SUFFIX ""
-    GL_20_FUN;
+    gl.GetProcAddress = gl._impl_GetProcAddress = SDL_GL_GetProcAddress;
     gl.MakeCurrent = commandMakeCurrent;
     gl._impl_MakeCurrent = [](SDL_Window *window, SDL_GLContext context) {
         return SDL_GL_MakeCurrent(window, context) < 0 ? SDL_GetError() : nullptr;
@@ -1032,6 +1043,9 @@ void initGLFunctions(SDL_Window *window, SDL_GLContext context)
     gl._impl_GetSwapInterval = SDL_GL_GetSwapInterval;
     gl.SwapWindow = commandSwapWindow;
     gl._impl_SwapWindow = SDL_GL_SwapWindow;
+
+#define EXT_SUFFIX ""
+    GL_20_FUN;
 
     gl.multithreaded = true;
 
@@ -1061,6 +1075,8 @@ void initGLFunctions(SDL_Window *window, SDL_GLContext context)
             }
         }
     }
+
+    gl.GetProcAddress = commandGetProcAddress;
 
     /* Determine GL version */
     const char *ver = (const char*) gl.GetString(GL_VERSION);

--- a/src/display/gl/gl-fun.cpp
+++ b/src/display/gl/gl-fun.cpp
@@ -1040,7 +1040,7 @@ int glThreadFun(void *userdata)
     return 0;
 }
 
-void initGLFunctions(SDL_Window *window, SDL_GLContext context)
+void initGLFunctions(const Config &conf, SDL_Window *window, SDL_GLContext context)
 {
     gl.GetProcAddress = gl._impl_GetProcAddress = SDL_GL_GetProcAddress;
     gl.MakeCurrent = commandMakeCurrent;
@@ -1059,24 +1059,34 @@ void initGLFunctions(SDL_Window *window, SDL_GLContext context)
 
     gl.multithreaded = true;
 
-    /* ANGLE doesn't support KHR_context_flush_control but doesn't flush the OpenGL pipeline when the context is bound/unbound,
-     * so consider the release behavior to be GL_NONE when using ANGLE on any platform.
-     * Core OpenGL (CGL) also neither supports KHR_context_flush_control nor flushes the pipeline on context binding/unbinding,
-     * so also consider the release behavior to be GL_NONE on Apple platforms when ANGLE is not being used. */
+    switch (conf.multithreadedGl) {
+        default:
+            /* ANGLE doesn't support KHR_context_flush_control but doesn't flush the OpenGL pipeline when the context is bound/unbound,
+             * so consider the release behavior to be GL_NONE when using ANGLE on any platform.
+             * Core OpenGL (CGL) also neither supports KHR_context_flush_control nor flushes the pipeline on context binding/unbinding,
+             * so also consider the release behavior to be GL_NONE on Apple platforms when ANGLE is not being used. */
 #ifdef __APPLE__
-    gl.context_release_behavior_none = true;
+            gl.context_release_behavior_none = true;
 #else
 #  ifdef MKXPZ_HAVE_ANGLE
-    if (mkxp_use_angle)
-        gl.context_release_behavior_none = true;
-    else
+            if (mkxp_use_angle)
+                gl.context_release_behavior_none = true;
+            else
 #  endif // MKXPZ_HAVE_ANGLE
-    {
-        GLint context_release_behavior = 0x82fc /* GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH */;
-        gl._impl_GetIntegerv(0x82fb /* GL_CONTEXT_RELEASE_BEHAVIOR */, &context_release_behavior);
-        gl.context_release_behavior_none = context_release_behavior == GL_NONE;
-    }
+            {
+                GLint context_release_behavior = 0x82fc /* GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH */;
+                gl._impl_GetIntegerv(0x82fb /* GL_CONTEXT_RELEASE_BEHAVIOR */, &context_release_behavior);
+                gl.context_release_behavior_none = context_release_behavior == GL_NONE;
+            }
 #endif // __APPLE__
+            break;
+        case 1:
+            gl.context_release_behavior_none = true;
+            break;
+        case 2:
+            gl.context_release_behavior_none = false;
+            break;
+    }
 
     if (gl.context_release_behavior_none) {
         gl.thread = nullptr;

--- a/src/display/gl/gl-fun.cpp
+++ b/src/display/gl/gl-fun.cpp
@@ -1036,8 +1036,8 @@ void initGLFunctions(SDL_Window *window, SDL_GLContext context)
     gl.multithreaded = true;
 
     {
-        GLint context_release_behavior = GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH;
-        gl._impl_GetIntegerv(GL_CONTEXT_RELEASE_BEHAVIOR, &context_release_behavior);
+        GLint context_release_behavior = 0x82fc /* GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH */;
+        gl._impl_GetIntegerv(0x82fb /* GL_CONTEXT_RELEASE_BEHAVIOR */, &context_release_behavior);
         gl.context_release_behavior_none = context_release_behavior == GL_NONE;
     }
 

--- a/src/display/gl/gl-fun.cpp
+++ b/src/display/gl/gl-fun.cpp
@@ -1024,9 +1024,9 @@ int glThreadFun(void *userdata)
         DEF_COMMAND_HANDLER(SwapWindow, command.window),
     };
     std::unique_lock<std::mutex> guard(gl.mutex);
-    gl.commandId = 0;
-    gl.cond.notify_one();
     for (;;) {
+        gl.commandId = 0;
+        gl.cond.notify_one();
         do {
             gl.cond.wait(guard);
         } while (gl.commandId == 0);
@@ -1034,8 +1034,6 @@ int glThreadFun(void *userdata)
             return 0;
         }
         handlers[gl.commandId - 1]();
-        gl.commandId = 0;
-        gl.cond.notify_one();
     }
     return 0;
 }

--- a/src/display/gl/gl-fun.cpp
+++ b/src/display/gl/gl-fun.cpp
@@ -388,7 +388,6 @@ static void commandActiveTexture(GLenum texture)
     EXECUTE_COMMAND(ActiveTexture, texture);
 }
 
-
 struct CommandGenerateMipmap
 {
     DECLARE_COMMAND_ID;
@@ -569,7 +568,6 @@ static void commandGetShaderInfoLog(GLuint shader, GLsizei bufSize, GLsizei *len
 {
     EXECUTE_COMMAND(GetShaderInfoLog, shader, bufSize, length, infoLog);
 }
-
 
 struct CommandCreateProgram
 {

--- a/src/display/gl/gl-fun.cpp
+++ b/src/display/gl/gl-fun.cpp
@@ -27,6 +27,10 @@
 #include <string>
 #include <utility>
 
+#ifdef MKXPZ_HAVE_ANGLE
+extern bool mkxp_use_angle;
+#endif // MKXPZ_HAVE_ANGLE
+
 GLFunctions gl;
 
 typedef const GLubyte* (APIENTRYP _PFNGLGETSTRINGIPROC) (GLenum, GLuint);
@@ -1055,19 +1059,24 @@ void initGLFunctions(SDL_Window *window, SDL_GLContext context)
 
     gl.multithreaded = true;
 
-#ifdef __APPLE__
     /* ANGLE doesn't support KHR_context_flush_control but doesn't flush the OpenGL pipeline when the context is bound/unbound,
      * so consider the release behavior to be GL_NONE when using ANGLE on any platform.
      * Core OpenGL (CGL) also neither supports KHR_context_flush_control nor flushes the pipeline on context binding/unbinding,
      * so also consider the release behavior to be GL_NONE on Apple platforms when ANGLE is not being used. */
+#ifdef __APPLE__
     gl.context_release_behavior_none = true;
 #else
+#  ifdef MKXPZ_HAVE_ANGLE
+    if (mkxp_use_angle)
+        gl.context_release_behavior_none = true;
+    else
+#  endif // MKXPZ_HAVE_ANGLE
     {
         GLint context_release_behavior = 0x82fc /* GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH */;
         gl._impl_GetIntegerv(0x82fb /* GL_CONTEXT_RELEASE_BEHAVIOR */, &context_release_behavior);
         gl.context_release_behavior_none = context_release_behavior == GL_NONE;
     }
-#endif
+#endif // __APPLE__
 
     if (gl.context_release_behavior_none) {
         gl.thread = nullptr;

--- a/src/display/gl/gl-fun.cpp
+++ b/src/display/gl/gl-fun.cpp
@@ -24,9 +24,6 @@
 #include "boost-hash.h"
 #include "exception.h"
 
-#include <SDL_video.h>
-#include <condition_variable>
-#include <mutex>
 #include <string>
 #include <utility>
 

--- a/src/display/gl/gl-fun.cpp
+++ b/src/display/gl/gl-fun.cpp
@@ -99,13 +99,15 @@ template <typename Command> struct CommandResult<Command, decltype(std::declval<
     gl.commandId = command.commandId; \
     gl.command = &command; \
     gl.cond.notify_one(); \
-    gl.cond.wait(guard); \
+    while (gl.commandId != 0) { \
+        gl.cond.wait(guard); \
+    } \
     return CommandResult<Command##name>::get(command); \
 } while (0)
 
 static constexpr size_t startingCommandId = __COUNTER__;
 
-#define DECLARE_COMMAND_ID static constexpr size_t commandId = (size_t)__COUNTER__ - (size_t)1 - startingCommandId
+#define DECLARE_COMMAND_ID static constexpr size_t commandId = (size_t)__COUNTER__ - startingCommandId
 
 struct CommandGetError
 {
@@ -931,13 +933,13 @@ static void commandSwapWindow(SDL_Window *window)
 Exception(Exception::MKXPError, "%s", msg)
 
 #define DEF_COMMAND_HANDLER(name, ...) []() { \
-    static_assert(Command##name::commandId == (size_t)__COUNTER__ - (size_t)1 - startingCommandHandlerId, "command handlers need to be defined in the same order as the command commands themselves"); \
+    static_assert(Command##name::commandId == (size_t)__COUNTER__ - startingCommandHandlerId, "command handlers need to be defined in the same order as the command commands themselves"); \
     Command##name &command = *(Command##name *)gl.command; \
     CommandResult<Command##name>::set(command, gl._impl_##name, __VA_ARGS__); \
 }
 
 #define DEF_COMMAND_HANDLER_NO_ARGS(name) []() { \
-    static_assert(Command##name::commandId == (size_t)__COUNTER__ - (size_t)1 - startingCommandHandlerId, "command handlers need to be defined in the same order as the command commands themselves"); \
+    static_assert(Command##name::commandId == (size_t)__COUNTER__ - startingCommandHandlerId, "command handlers need to be defined in the same order as the command commands themselves"); \
     Command##name &command = *(Command##name *)gl.command; \
     CommandResult<Command##name>::set(command, gl._impl_##name); \
 }
@@ -1018,13 +1020,17 @@ int glThreadFun(void *userdata)
         DEF_COMMAND_HANDLER(SwapWindow, command.window),
     };
     std::unique_lock<std::mutex> guard(gl.mutex);
+    gl.commandId = 0;
     gl.cond.notify_one();
     for (;;) {
-        gl.cond.wait(guard);
-        if (gl.commandId >= sizeof handlers / sizeof *handlers) {
+        while (gl.commandId == 0) {
+            gl.cond.wait(guard);
+        }
+        if (gl.commandId > sizeof handlers / sizeof *handlers) {
             return 0;
         }
-        handlers[gl.commandId]();
+        handlers[gl.commandId - 1]();
+        gl.commandId = 0;
         gl.cond.notify_one();
     }
     return 0;
@@ -1063,10 +1069,13 @@ void initGLFunctions(SDL_Window *window, SDL_GLContext context)
         }
         {
             std::unique_lock<std::mutex> guard(gl.mutex);
+            gl.commandId = -1;
             if ((gl.thread = SDL_CreateThread(glThreadFun, "gl", nullptr)) == nullptr) {
                 throw Exception(Exception::MKXPError, "Could not create OpenGL thread: %s", SDL_GetError());
             }
-            gl.cond.wait(guard);
+            while (gl.commandId != 0) {
+                gl.cond.wait(guard);
+            }
         }
         if (gl.multithreaded) {
             const char *error = gl.MakeCurrent(window, context);

--- a/src/display/gl/gl-fun.cpp
+++ b/src/display/gl/gl-fun.cpp
@@ -23,6 +23,8 @@
 
 #include "boost-hash.h"
 #include "exception.h"
+#include "graphics.h"
+#include "sharedstate.h"
 
 #include <string>
 #include <utility>
@@ -94,6 +96,9 @@ template <typename Command> struct CommandResult<Command, decltype(std::declval<
 #define EXECUTE_COMMAND(name, ...) do { \
     if (!gl.multithreaded && SDL_GL_GetCurrentContext() == nullptr) { \
         throw Exception(Exception::MKXPError, "Cannot call this function from outside of the graphics thread when Graphics.thread_safe == false"); \
+    } \
+    if (shState != nullptr && !shState->graphics().isLocked()) { \
+        throw Exception(Exception::MKXPError, "Attempted to call gl" #name " without locking the graphics state"); \
     } \
     if (gl.context_release_behavior_none || !gl.multithreaded) { \
         return gl._impl_##name(__VA_ARGS__); \

--- a/src/display/gl/gl-fun.cpp
+++ b/src/display/gl/gl-fun.cpp
@@ -94,11 +94,11 @@ template <typename Command> struct CommandResult<Command, decltype(std::declval<
 };
 
 #define EXECUTE_COMMAND(name, ...) do { \
-    if (!gl.multithreaded && SDL_GL_GetCurrentContext() == nullptr) { \
-        throw Exception(Exception::MKXPError, "Cannot call this function from outside of the graphics thread when Graphics.thread_safe == false"); \
-    } \
     if (shState != nullptr && !shState->graphics().isLocked()) { \
         throw Exception(Exception::MKXPError, "Attempted to call gl" #name " without locking the graphics state"); \
+    } \
+    if (!gl.multithreaded && SDL_GL_GetCurrentContext() == nullptr) { \
+        throw Exception(Exception::MKXPError, "Cannot call this function from outside of the graphics thread when Graphics.thread_safe == false"); \
     } \
     if (gl.context_release_behavior_none || !gl.multithreaded) { \
         return gl._impl_##name(__VA_ARGS__); \

--- a/src/display/gl/gl-fun.h
+++ b/src/display/gl/gl-fun.h
@@ -34,6 +34,8 @@
 #include <SDL_thread.h>
 #include <SDL_video.h>
 
+#include "config.h"
+
 #define SDL_GL_GetProcAddress(...) ([]{static_assert(false, "please use gl.GetProcAddress() instead of SDL_GL_GetProcAddress()"); return (void *)nullptr;})()
 #define SDL_GL_SetSwapInterval(...) ([]{static_assert(false, "please use gl.SetSwapInterval() instead of SDL_GL_SetSwapInterval()"); return (int)-1;})()
 #define SDL_GL_GetSwapInterval(...) ([]{static_assert(false, "please use gl.GetSwapInterval() instead of SDL_GL_GetSwapInterval()"); return (int)0;})()
@@ -263,7 +265,7 @@ struct GLFunctions
 };
 
 extern GLFunctions gl;
-void initGLFunctions(SDL_Window *window, SDL_GLContext context);
+void initGLFunctions(const Config &conf, SDL_Window *window, SDL_GLContext context);
 int glThreadFun(void *userdata);
 
 #endif // GLFUN_H

--- a/src/display/gl/gl-fun.h
+++ b/src/display/gl/gl-fun.h
@@ -31,6 +31,8 @@
 #else
 #include <SDL_opengl.h>
 #endif
+#include <SDL_thread.h>
+#include <SDL_video.h>
 
 #define SDL_GL_SetSwapInterval(...) static_assert(false, "please use gl.SetSwapInterval() instead of SDL_GL_SetSwapInterval()")
 #define SDL_GL_GetSwapInterval(...) static_assert(false, "please use gl.GetSwapInterval() instead of SDL_GL_GetSwapInterval()")

--- a/src/display/gl/gl-fun.h
+++ b/src/display/gl/gl-fun.h
@@ -34,10 +34,10 @@
 #include <SDL_thread.h>
 #include <SDL_video.h>
 
-#define SDL_GL_GetProcAddress(...) static_assert(false, "please use gl.GetProcAddress() instead of SDL_GL_GetProcAddress()")
-#define SDL_GL_SetSwapInterval(...) static_assert(false, "please use gl.SetSwapInterval() instead of SDL_GL_SetSwapInterval()")
-#define SDL_GL_GetSwapInterval(...) static_assert(false, "please use gl.GetSwapInterval() instead of SDL_GL_GetSwapInterval()")
-#define SDL_GL_SwapWindow(...) static_assert(false, "please use gl.SwapWindow() instead of SDL_GL_SwapWindow()")
+#define SDL_GL_GetProcAddress(...) ([]{static_assert(false, "please use gl.GetProcAddress() instead of SDL_GL_GetProcAddress()"); return (void *)nullptr;})()
+#define SDL_GL_SetSwapInterval(...) ([]{static_assert(false, "please use gl.SetSwapInterval() instead of SDL_GL_SetSwapInterval()"); return (int)-1;})()
+#define SDL_GL_GetSwapInterval(...) ([]{static_assert(false, "please use gl.GetSwapInterval() instead of SDL_GL_GetSwapInterval()"); return (int)0;})()
+#define SDL_GL_SwapWindow(...) ([]{static_assert(false, "please use gl.SwapWindow() instead of SDL_GL_SwapWindow()");})()
 
 /* Etc */
 typedef GLenum (APIENTRYP _PFNGLGETERRORPROC) (void);

--- a/src/display/gl/gl-fun.h
+++ b/src/display/gl/gl-fun.h
@@ -22,6 +22,9 @@
 #ifndef GLFUN_H
 #define GLFUN_H
 
+#include <condition_variable>
+#include <mutex>
+
 #ifdef GLES2_HEADER
 #include <SDL_opengles2.h>
 #define APIENTRYP GL_APIENTRYP
@@ -29,11 +32,16 @@
 #include <SDL_opengl.h>
 #endif
 
+#define SDL_GL_SetSwapInterval(__VA_ARGS__) static_assert(false, "please use gl.SetSwapInterval() instead of SDL_GL_SetSwapInterval()")
+#define SDL_GL_GetSwapInterval(__VA_ARGS__) static_assert(false, "please use gl.GetSwapInterval() instead of SDL_GL_GetSwapInterval()")
+#define SDL_GL_SwapWindow(__VA_ARGS__) static_assert(false, "please use gl.SwapWindow() instead of SDL_GL_SwapWindow()")
+
 /* Etc */
 typedef GLenum (APIENTRYP _PFNGLGETERRORPROC) (void);
 typedef void (APIENTRYP _PFNGLCLEARCOLORPROC) (GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha);
 typedef void (APIENTRYP _PFNGLCLEARPROC) (GLbitfield mask);
 typedef const GLubyte * (APIENTRYP _PFNGLGETSTRINGPROC) (GLenum name);
+typedef const GLubyte * (APIENTRYP _PFNGLGETSTRINGIPROC) (GLenum name, GLuint index);
 typedef void (APIENTRYP _PFNGLGETINTEGERVPROC) (GLenum pname, GLint *params);
 typedef void (APIENTRYP _PFNGLPIXELSTOREIPROC) (GLenum pname, GLint param);
 typedef void (APIENTRYP _PFNGLREADPIXELSPROC) (GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLvoid *pixels);
@@ -131,6 +139,7 @@ typedef void (APIENTRYP _PFNGLRELEASESHADERCOMPILERPROC) (void);
 	GL_FUN(ClearColor, _PFNGLCLEARCOLORPROC) \
 	GL_FUN(Clear, _PFNGLCLEARPROC) \
 	GL_FUN(GetString, _PFNGLGETSTRINGPROC) \
+	GL_FUN(GetStringi, _PFNGLGETSTRINGIPROC) \
 	GL_FUN(GetIntegerv, _PFNGLGETINTEGERVPROC) \
 	GL_FUN(PixelStorei, _PFNGLPIXELSTOREIPROC) \
 	GL_FUN(ReadPixels, _PFNGLREADPIXELSPROC) \
@@ -215,7 +224,7 @@ typedef void (APIENTRYP _PFNGLRELEASESHADERCOMPILERPROC) (void);
 
 struct GLFunctions
 {
-#define GL_FUN(name, type) type name;
+#define GL_FUN(name, type) type name; type _impl_##name;
 
 	GL_20_FUN
 	GL_ES_FUN
@@ -224,15 +233,32 @@ struct GLFunctions
 	GL_VAO_FUN
 	GL_DEBUG_KHR_FUN
 	GL_GREMEMDY_FUN
+	const char *(*MakeCurrent)(SDL_Window *window, SDL_GLContext context);
+	const char *(*_impl_MakeCurrent)(SDL_Window *window, SDL_GLContext context);
+	int (*SetSwapInterval)(int interval);
+	int (*_impl_SetSwapInterval)(int interval);
+	int (*GetSwapInterval)(void);
+	int (*_impl_GetSwapInterval)(void);
+	void (*SwapWindow)(SDL_Window *window);
+	void (*_impl_SwapWindow)(SDL_Window *window);
 
 	bool glsles;
 	bool unpack_subimage;
 	bool npot_repeat;
+	bool context_release_behavior_none;
+	bool multithreaded;
+
+	SDL_Thread *thread;
+	std::mutex mutex;
+	std::condition_variable cond;
+	size_t commandId;
+	void *command;
 
 #undef GL_FUN
 };
 
 extern GLFunctions gl;
-void initGLFunctions();
+void initGLFunctions(SDL_Window *window, SDL_GLContext context);
+int glThreadFun(void *userdata);
 
 #endif // GLFUN_H

--- a/src/display/gl/gl-fun.h
+++ b/src/display/gl/gl-fun.h
@@ -34,6 +34,7 @@
 #include <SDL_thread.h>
 #include <SDL_video.h>
 
+#define SDL_GL_GetProcAddress(...) static_assert(false, "please use gl.GetProcAddress() instead of SDL_GL_GetProcAddress()")
 #define SDL_GL_SetSwapInterval(...) static_assert(false, "please use gl.SetSwapInterval() instead of SDL_GL_SetSwapInterval()")
 #define SDL_GL_GetSwapInterval(...) static_assert(false, "please use gl.GetSwapInterval() instead of SDL_GL_GetSwapInterval()")
 #define SDL_GL_SwapWindow(...) static_assert(false, "please use gl.SwapWindow() instead of SDL_GL_SwapWindow()")
@@ -235,6 +236,8 @@ struct GLFunctions
 	GL_VAO_FUN
 	GL_DEBUG_KHR_FUN
 	GL_GREMEMDY_FUN
+	void *(*GetProcAddress)(const char *proc);
+	void *(*_impl_GetProcAddress)(const char *proc);
 	const char *(*MakeCurrent)(SDL_Window *window, SDL_GLContext context);
 	const char *(*_impl_MakeCurrent)(SDL_Window *window, SDL_GLContext context);
 	int (*SetSwapInterval)(int interval);

--- a/src/display/gl/gl-fun.h
+++ b/src/display/gl/gl-fun.h
@@ -32,9 +32,9 @@
 #include <SDL_opengl.h>
 #endif
 
-#define SDL_GL_SetSwapInterval(__VA_ARGS__) static_assert(false, "please use gl.SetSwapInterval() instead of SDL_GL_SetSwapInterval()")
-#define SDL_GL_GetSwapInterval(__VA_ARGS__) static_assert(false, "please use gl.GetSwapInterval() instead of SDL_GL_GetSwapInterval()")
-#define SDL_GL_SwapWindow(__VA_ARGS__) static_assert(false, "please use gl.SwapWindow() instead of SDL_GL_SwapWindow()")
+#define SDL_GL_SetSwapInterval(...) static_assert(false, "please use gl.SetSwapInterval() instead of SDL_GL_SetSwapInterval()")
+#define SDL_GL_GetSwapInterval(...) static_assert(false, "please use gl.GetSwapInterval() instead of SDL_GL_GetSwapInterval()")
+#define SDL_GL_SwapWindow(...) static_assert(false, "please use gl.SwapWindow() instead of SDL_GL_SwapWindow()")
 
 /* Etc */
 typedef GLenum (APIENTRYP _PFNGLGETERRORPROC) (void);

--- a/src/display/gl/quad.h
+++ b/src/display/gl/quad.h
@@ -91,8 +91,10 @@ struct Quad
 
 	~Quad()
 	{
+		GFX_LOCK;
 		GLMeta::vaoFini(vao);
 		VBO::del(vbo);
+		GFX_UNLOCK;
 	}
 
 	void updateBuffer()

--- a/src/display/gl/shader.cpp
+++ b/src/display/gl/shader.cpp
@@ -126,9 +126,11 @@ Shader::Shader() : initialized(false)
 
 Shader::~Shader()
 {
+	GFX_LOCK;
 	gl.DeleteProgram(program);
 	gl.DeleteShader(vertShader);
 	gl.DeleteShader(fragShader);
+	GFX_UNLOCK;
 }
 
 void Shader::bind()

--- a/src/display/gl/texpool.cpp
+++ b/src/display/gl/texpool.cpp
@@ -25,6 +25,7 @@
 #include "glstate.h"
 #include "boost-hash.h"
 #include "debugwriter.h"
+#include "graphics.h"
 
 #include <list>
 #include <utility>
@@ -86,6 +87,8 @@ TexPool::TexPool(uint32_t maxMemSize)
 
 TexPool::~TexPool()
 {
+	GFX_LOCK;
+
 	std::list<TEXFBO>::iterator iter;
 
 	for (iter = p->priorityQueue.begin();
@@ -100,6 +103,8 @@ TexPool::~TexPool()
 	assert(p->objCount == 0);
 
 	delete p;
+
+	GFX_UNLOCK;
 }
 
 TEXFBO TexPool::request(int width, int height)

--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -1746,21 +1746,13 @@ void Graphics::repaintWait(const AtomicFlag &exitCond, bool checkReset) {
     if (exitCond)
         return;
     
-    int scaleIsSpecial;
-    GFX_LOCK;
-    try {
-        /* Repaint the screen with the last good frame we drew */
-        TEXFBO &lastFrame = p->screen.getPP().frontBuffer();
+    /* Repaint the screen with the last good frame we drew */
+    TEXFBO &lastFrame = p->screen.getPP().frontBuffer();
 
-        scaleIsSpecial = GLMeta::blitScaleIsSpecial(p->integerScaleBuffer, false, IntRect(0, 0, p->scSize.x, p->scSize.y), lastFrame, IntRect(0, 0, p->scRes.x, p->scRes.y));
+    int scaleIsSpecial = GLMeta::blitScaleIsSpecial(p->integerScaleBuffer, false, IntRect(0, 0, p->scSize.x, p->scSize.y), lastFrame, IntRect(0, 0, p->scRes.x, p->scRes.y));
 
-        GLMeta::blitBeginScreen(p->winSize, scaleIsSpecial);
-        GLMeta::blitSource(lastFrame, scaleIsSpecial);
-    } catch (...) {
-        GFX_UNLOCK;
-        throw;
-    }
-    GFX_UNLOCK;
+    GLMeta::blitBeginScreen(p->winSize, scaleIsSpecial);
+    GLMeta::blitSource(lastFrame, scaleIsSpecial);
     
     while (!exitCond) {
         shState->checkShutdown();
@@ -1768,29 +1760,15 @@ void Graphics::repaintWait(const AtomicFlag &exitCond, bool checkReset) {
         if (checkReset)
             shState->checkReset();
         
-        GFX_LOCK;
-        try {
-            FBO::clear();
-            p->metaBlitBufferFlippedScaled(scaleIsSpecial);
-            gl.SwapWindow(p->threadData->window);
-        } catch (...) {
-            GFX_UNLOCK;
-            throw;
-        }
-        GFX_UNLOCK;
+        FBO::clear();
+        p->metaBlitBufferFlippedScaled(scaleIsSpecial);
+        gl.SwapWindow(p->threadData->window);
         p->fpsLimiter.delay();
         
         p->threadData->ethread->notifyFrame();
     }
     
-    GFX_LOCK;
-    try {
-        GLMeta::blitEnd();
-    } catch (...) {
-        GFX_UNLOCK;
-        throw;
-    }
-    GFX_UNLOCK;
+    GLMeta::blitEnd();
 }
 
 void Graphics::lock() {

--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -1710,8 +1710,8 @@ void Graphics::setThreadsafe(bool value)
             SDL_GL_MakeCurrent(p->threadData->window, nullptr);
             gl.MakeCurrent(p->threadData->window, p->threadData->glContext);
         } else {
-            SDL_GL_MakeCurrent(p->threadData->window, p->threadData->glContext);
             gl.MakeCurrent(p->threadData->window, nullptr);
+            SDL_GL_MakeCurrent(p->threadData->window, p->threadData->glContext);
         }
     }
     gl.multithreaded = value;

--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -1746,13 +1746,21 @@ void Graphics::repaintWait(const AtomicFlag &exitCond, bool checkReset) {
     if (exitCond)
         return;
     
-    /* Repaint the screen with the last good frame we drew */
-    TEXFBO &lastFrame = p->screen.getPP().frontBuffer();
+    int scaleIsSpecial;
+    GFX_LOCK;
+    try {
+        /* Repaint the screen with the last good frame we drew */
+        TEXFBO &lastFrame = p->screen.getPP().frontBuffer();
 
-    int scaleIsSpecial = GLMeta::blitScaleIsSpecial(p->integerScaleBuffer, false, IntRect(0, 0, p->scSize.x, p->scSize.y), lastFrame, IntRect(0, 0, p->scRes.x, p->scRes.y));
+        scaleIsSpecial = GLMeta::blitScaleIsSpecial(p->integerScaleBuffer, false, IntRect(0, 0, p->scSize.x, p->scSize.y), lastFrame, IntRect(0, 0, p->scRes.x, p->scRes.y));
 
-    GLMeta::blitBeginScreen(p->winSize, scaleIsSpecial);
-    GLMeta::blitSource(lastFrame, scaleIsSpecial);
+        GLMeta::blitBeginScreen(p->winSize, scaleIsSpecial);
+        GLMeta::blitSource(lastFrame, scaleIsSpecial);
+    } catch (...) {
+        GFX_UNLOCK;
+        throw;
+    }
+    GFX_UNLOCK;
     
     while (!exitCond) {
         shState->checkShutdown();
@@ -1760,15 +1768,29 @@ void Graphics::repaintWait(const AtomicFlag &exitCond, bool checkReset) {
         if (checkReset)
             shState->checkReset();
         
-        FBO::clear();
-        p->metaBlitBufferFlippedScaled(scaleIsSpecial);
-        gl.SwapWindow(p->threadData->window);
+        GFX_LOCK;
+        try {
+            FBO::clear();
+            p->metaBlitBufferFlippedScaled(scaleIsSpecial);
+            gl.SwapWindow(p->threadData->window);
+        } catch (...) {
+            GFX_UNLOCK;
+            throw;
+        }
+        GFX_UNLOCK;
         p->fpsLimiter.delay();
         
         p->threadData->ethread->notifyFrame();
     }
     
-    GLMeta::blitEnd();
+    GFX_LOCK;
+    try {
+        GLMeta::blitEnd();
+    } catch (...) {
+        GFX_UNLOCK;
+        throw;
+    }
+    GFX_UNLOCK;
 }
 
 void Graphics::lock() {

--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -830,7 +830,7 @@ struct GraphicsPrivate {
     SDL_mutex *avgFPSLock;
     
     SDL_mutex *glResourceLock;
-    bool multithreadedMode;
+    uint64_t glResourceLockLevel;
     
     /* Global list of all live Disposables
      * (disposed on reset) */
@@ -843,7 +843,7 @@ struct GraphicsPrivate {
     scSize(scRes),
     winSize(rtData->config.defScreenW, rtData->config.defScreenH),
     screen(scRes.x, scRes.y), threadData(rtData),
-    glCtx(SDL_GL_GetCurrentContext()), multithreadedMode(true),
+    glCtx(SDL_GL_GetCurrentContext()),
     frameRate(DEF_FRAMERATE), frameCount(0), brightness(255),
     fpsLimiter(frameRate), useFrameSkip(rtData->config.frameSkip), frozen(false),
     last_update(0), last_avg_update(0), backingScaleFactor(1), integerScaleFactor(0, 0),
@@ -852,6 +852,7 @@ struct GraphicsPrivate {
         avgFPSData = std::vector<double>();
         avgFPSLock = SDL_CreateMutex();
         glResourceLock = SDL_CreateMutex();
+        glResourceLockLevel = 0;
         
         if (integerScaleActive) {
             integerScaleFactor = Vec2i(0, 0);
@@ -1003,7 +1004,7 @@ struct GraphicsPrivate {
     
     void swapGLBuffer() {
         fpsLimiter.delay();
-        SDL_GL_SwapWindow(threadData->window);
+        gl.SwapWindow(threadData->window);
         
         ++frameCount;
         
@@ -1117,12 +1118,7 @@ struct GraphicsPrivate {
         if (!threadData->syncPoint.mainSyncLocked())
             return;
         
-        /* Releasing the GL context before sleeping and making it
-         * current again on wakeup seems to avoid the context loss
-         * when the app moves into the background on Android */
-        SDL_GL_MakeCurrent(threadData->window, 0);
         threadData->syncPoint.waitMainSync();
-        SDL_GL_MakeCurrent(threadData->window, glCtx);
         
         fpsLimiter.resetFrameAdjust();
     }
@@ -1138,16 +1134,18 @@ struct GraphicsPrivate {
         return ret;
     }
     
-    void setLock(bool force = false) {
-        if (!(force || multithreadedMode)) return;
-        
+    void setLock() {
         SDL_LockMutex(glResourceLock);
-        SDL_GL_MakeCurrent(threadData->window, threadData->glContext);
+        if (glResourceLockLevel++ == 0 && gl.context_release_behavior_none && gl.multithreaded) {
+            SDL_GL_MakeCurrent(threadData->window, threadData->glContext);
+        }
     }
     
-    void releaseLock(bool force = false) {
-        if (!(force || multithreadedMode)) return;
-        
+    void releaseLock() {
+        assert(glResourceLockLevel > 0);
+        if (--glResourceLockLevel == 0 && gl.context_release_behavior_none && gl.multithreaded) {
+            SDL_GL_MakeCurrent(threadData->window, nullptr);
+        }
         SDL_UnlockMutex(glResourceLock);
     }
 
@@ -1702,12 +1700,21 @@ void Graphics::setLastMileScaling(bool value)
 
 bool Graphics::getThreadsafe() const
 {
-    return p->multithreadedMode;
+    return gl.multithreaded;
 }
 
 void Graphics::setThreadsafe(bool value)
 {
-    p->multithreadedMode = value;
+    if (!gl.context_release_behavior_none && value != gl.multithreaded) {
+        if (value) {
+            SDL_GL_MakeCurrent(p->threadData->window, nullptr);
+            gl.MakeCurrent(p->threadData->window, p->threadData->glContext);
+        } else {
+            SDL_GL_MakeCurrent(p->threadData->window, p->threadData->glContext);
+            gl.MakeCurrent(p->threadData->window, nullptr);
+        }
+    }
+    gl.multithreaded = value;
 }
 
 double Graphics::getScale() const {
@@ -1755,7 +1762,7 @@ void Graphics::repaintWait(const AtomicFlag &exitCond, bool checkReset) {
         
         FBO::clear();
         p->metaBlitBufferFlippedScaled(scaleIsSpecial);
-        SDL_GL_SwapWindow(p->threadData->window);
+        gl.SwapWindow(p->threadData->window);
         p->fpsLimiter.delay();
         
         p->threadData->ethread->notifyFrame();
@@ -1764,12 +1771,12 @@ void Graphics::repaintWait(const AtomicFlag &exitCond, bool checkReset) {
     GLMeta::blitEnd();
 }
 
-void Graphics::lock(bool force) {
-    p->setLock(force);
+void Graphics::lock() {
+    p->setLock();
 }
 
-void Graphics::unlock(bool force) {
-    p->releaseLock(force);
+void Graphics::unlock() {
+    p->releaseLock();
 }
 
 void Graphics::addDisposable(Disposable *d) { p->dispList.append(d->link); }

--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -1556,9 +1556,10 @@ void Graphics::resizeWindow(int width, int height, bool center) {
 }
 
 void Graphics::onSizeChanged() {
-    // We need to repaint the screen after resizing when using ANGLE's Direct3D 11 backend.
+    // We need to repaint the screen after resizing when using ANGLE's Direct3D 11 backend, twice (probably because of double buffering).
     GFX_LOCK;
     p->checkResize();
+    p->redrawScreen(false);
     p->redrawScreen(false);
     GFX_UNLOCK;
 }

--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -1051,7 +1051,7 @@ struct GraphicsPrivate {
                               !forceNearestNeighbor && GLMeta::smoothScalingMethod(scaleIsSpecial) == Bilinear);
     }
     
-    void redrawScreen() {
+    void redrawScreen(bool incrementFrameCount = true) {
         screen.composite();
         
         // maybe unspaghetti this later
@@ -1066,8 +1066,15 @@ struct GraphicsPrivate {
             metaBlitBufferFlippedScaled(scRes, scaleIsSpecial, true);
             GLMeta::blitEnd();
             
-            swapGLBuffer();
-            updateAvgFPS();
+            if (incrementFrameCount)
+            {
+                swapGLBuffer();
+                updateAvgFPS();
+            }
+            else
+            {
+                gl.SwapWindow(threadData->window);
+            }
             return;
         }
         
@@ -1117,9 +1124,15 @@ struct GraphicsPrivate {
         
         GLMeta::blitEnd();
         
-        swapGLBuffer();
-        
-        updateAvgFPS();
+        if (incrementFrameCount)
+        {
+            swapGLBuffer();
+            updateAvgFPS();
+        }
+        else
+        {
+            gl.SwapWindow(threadData->window);
+        }
     }
     
     void checkSyncLock() {
@@ -1546,7 +1559,7 @@ void Graphics::onSizeChanged() {
     // We need to repaint the screen after resizing when using ANGLE's Direct3D 11 backend.
     GFX_LOCK;
     p->checkResize();
-    p->redrawScreen();
+    p->redrawScreen(false);
     GFX_UNLOCK;
 }
 

--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -881,6 +881,9 @@ struct GraphicsPrivate {
     
     ~GraphicsPrivate() {
         GFX_LOCK;
+        for (IntruListLink<Disposable> *iter = dispList.begin(); iter != dispList.end(); iter = iter->next) {
+            iter->data->dispose();
+        }
         dispList.clear();
         TEXFBO::fini(frozenScene);
         TEXFBO::fini(integerScaleBuffer);

--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -455,8 +455,10 @@ struct PingPong {
     }
     
     ~PingPong() {
+        GFX_LOCK;
         for (int i = 0; i < 2; ++i)
             TEXFBO::fini(rt[i]);
+        GFX_UNLOCK;
     }
     
     TEXFBO &backBuffer() { return rt[srcInd]; }
@@ -776,6 +778,18 @@ private:
 };
 
 struct GraphicsPrivate {
+    /* Having this field at the beginning ensures the locks are destroyed after all of the other fields of GraphicsPrivate are destroyed */
+    struct GraphicsPrivateLocks {
+        SDL_mutex *avgFPSLock;
+        SDL_mutex *glResourceLock;
+        uint64_t glResourceLockLevel;
+        GraphicsPrivateLocks() : avgFPSLock(SDL_CreateMutex()), glResourceLock(SDL_CreateMutex()), glResourceLockLevel(0) {}
+        ~GraphicsPrivateLocks() {
+            SDL_DestroyMutex(glResourceLock);
+            SDL_DestroyMutex(avgFPSLock);
+        }
+    } locks;
+
     /* Screen resolution, ie. the resolution at which
      * RGSS renders at (settable with Graphics.resize_screen).
      * Can only be changed from within RGSS */
@@ -827,10 +841,6 @@ struct GraphicsPrivate {
     
     std::vector<double> avgFPSData;
     double last_avg_update;
-    SDL_mutex *avgFPSLock;
-    
-    SDL_mutex *glResourceLock;
-    uint64_t glResourceLockLevel;
     
     /* Global list of all live Disposables
      * (disposed on reset) */
@@ -850,9 +860,6 @@ struct GraphicsPrivate {
     integerScaleActive(rtData->config.integerScaling.active),
     integerLastMileScaling(rtData->config.integerScaling.lastMileScaling) {
         avgFPSData = std::vector<double>();
-        avgFPSLock = SDL_CreateMutex();
-        glResourceLock = SDL_CreateMutex();
-        glResourceLockLevel = 0;
         
         if (integerScaleActive) {
             integerScaleFactor = Vec2i(0, 0);
@@ -873,10 +880,11 @@ struct GraphicsPrivate {
     }
     
     ~GraphicsPrivate() {
+        GFX_LOCK;
+        dispList.clear();
         TEXFBO::fini(frozenScene);
         TEXFBO::fini(integerScaleBuffer);
-        SDL_DestroyMutex(avgFPSLock);
-        SDL_DestroyMutex(glResourceLock);
+        GFX_UNLOCK;
     }
     
     void updateScreenResoRatio(RGSSThreadData *rtData) {
@@ -1125,39 +1133,39 @@ struct GraphicsPrivate {
     
     double averageFPS() {
         double ret = 0;
-        SDL_LockMutex(avgFPSLock);
+        SDL_LockMutex(locks.avgFPSLock);
         for (double times : avgFPSData)
             ret += times;
         
         ret = 1 / (ret / avgFPSData.size());
-        SDL_UnlockMutex(avgFPSLock);
+        SDL_UnlockMutex(locks.avgFPSLock);
         return ret;
     }
     
     void setLock() {
-        SDL_LockMutex(glResourceLock);
-        if (glResourceLockLevel++ == 0 && gl.context_release_behavior_none && gl.multithreaded) {
+        SDL_LockMutex(locks.glResourceLock);
+        if (locks.glResourceLockLevel++ == 0 && gl.context_release_behavior_none && gl.multithreaded) {
             SDL_GL_MakeCurrent(threadData->window, threadData->glContext);
         }
     }
     
     void releaseLock() {
-        assert(glResourceLockLevel > 0);
-        if (--glResourceLockLevel == 0 && gl.context_release_behavior_none && gl.multithreaded) {
+        assert(locks.glResourceLockLevel > 0);
+        if (--locks.glResourceLockLevel == 0 && gl.context_release_behavior_none && gl.multithreaded) {
             SDL_GL_MakeCurrent(threadData->window, nullptr);
         }
-        SDL_UnlockMutex(glResourceLock);
+        SDL_UnlockMutex(locks.glResourceLock);
     }
 
     void updateAvgFPS() {
-        SDL_LockMutex(avgFPSLock);
+        SDL_LockMutex(locks.avgFPSLock);
         if (avgFPSData.size() > 40)
             avgFPSData.erase(avgFPSData.begin());
         
         double time = shState->runTime();
         avgFPSData.push_back(time - last_avg_update);
         last_avg_update = time;
-        SDL_UnlockMutex(avgFPSLock);
+        SDL_UnlockMutex(locks.avgFPSLock);
     }
 };
 
@@ -1777,6 +1785,15 @@ void Graphics::lock() {
 
 void Graphics::unlock() {
     p->releaseLock();
+}
+
+bool Graphics::isLocked() noexcept {
+    if (SDL_TryLockMutex(p->locks.glResourceLock) == SDL_MUTEX_TIMEDOUT) {
+        return false;
+    }
+    bool locked = p->locks.glResourceLockLevel != 0;
+    SDL_UnlockMutex(p->locks.glResourceLock);
+    return locked;
 }
 
 void Graphics::addDisposable(Disposable *d) { p->dispList.append(d->link); }

--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -1559,10 +1559,9 @@ void Graphics::resizeWindow(int width, int height, bool center) {
 }
 
 void Graphics::onSizeChanged() {
-    // We need to repaint the screen after resizing when using ANGLE's Direct3D 11 backend, twice (probably because of double buffering).
+    // We need to repaint the screen after resizing when using ANGLE's Direct3D 11 backend.
     GFX_LOCK;
     p->checkResize();
-    p->redrawScreen(false);
     p->redrawScreen(false);
     GFX_UNLOCK;
 }

--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -1054,7 +1054,7 @@ struct GraphicsPrivate {
                               !forceNearestNeighbor && GLMeta::smoothScalingMethod(scaleIsSpecial) == Bilinear);
     }
     
-    void redrawScreen(bool incrementFrameCount = true) {
+    void redrawScreen() {
         screen.composite();
         
         // maybe unspaghetti this later
@@ -1069,15 +1069,8 @@ struct GraphicsPrivate {
             metaBlitBufferFlippedScaled(scRes, scaleIsSpecial, true);
             GLMeta::blitEnd();
             
-            if (incrementFrameCount)
-            {
-                swapGLBuffer();
-                updateAvgFPS();
-            }
-            else
-            {
-                gl.SwapWindow(threadData->window);
-            }
+            swapGLBuffer();
+            updateAvgFPS();
             return;
         }
         
@@ -1127,15 +1120,9 @@ struct GraphicsPrivate {
         
         GLMeta::blitEnd();
         
-        if (incrementFrameCount)
-        {
-            swapGLBuffer();
-            updateAvgFPS();
-        }
-        else
-        {
-            gl.SwapWindow(threadData->window);
-        }
+        swapGLBuffer();
+        
+        updateAvgFPS();
     }
     
     void checkSyncLock() {
@@ -1562,7 +1549,7 @@ void Graphics::onSizeChanged() {
     // We need to repaint the screen after resizing when using ANGLE's Direct3D 11 backend.
     GFX_LOCK;
     p->checkResize();
-    p->redrawScreen(false);
+    p->redrawScreen();
     GFX_UNLOCK;
 }
 

--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -1542,6 +1542,14 @@ void Graphics::resizeWindow(int width, int height, bool center) {
         this->center();
 }
 
+void Graphics::onSizeChanged() {
+    // We need to repaint the screen after resizing when using ANGLE's Direct3D 11 backend.
+    GFX_LOCK;
+    p->checkResize();
+    p->redrawScreen();
+    GFX_UNLOCK;
+}
+
 bool Graphics::updateMovieInput(Movie *movie) {
     return  p->threadData->rqTerm || p->threadData->rqReset;
 }

--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -1545,14 +1545,6 @@ void Graphics::resizeWindow(int width, int height, bool center) {
         this->center();
 }
 
-void Graphics::onSizeChanged() {
-    // We need to repaint the screen after resizing when using ANGLE's Direct3D 11 backend.
-    GFX_LOCK;
-    p->checkResize();
-    p->redrawScreen();
-    GFX_UNLOCK;
-}
-
 bool Graphics::updateMovieInput(Movie *movie) {
     return  p->threadData->rqTerm || p->threadData->rqReset;
 }

--- a/src/display/graphics.h
+++ b/src/display/graphics.h
@@ -95,8 +95,8 @@ public:
 	void repaintWait(const AtomicFlag &exitCond,
 	                 bool checkReset = true);
     
-    void lock(bool force = false);
-    void unlock(bool force = false);
+    void lock();
+    void unlock();
 
 private:
 	Graphics(RGSSThreadData *data);

--- a/src/display/graphics.h
+++ b/src/display/graphics.h
@@ -67,6 +67,7 @@ public:
     int displayHeight() const;
 	void resizeScreen(int width, int height);
     void resizeWindow(int width, int height, bool center=false);
+	void onSizeChanged();
 	void drawMovieFrame(const THEORAPLAY_VideoFrame* video, Bitmap *videoBitmap);
 	bool updateMovieInput(Movie *movie);
 	void playMovie(const char *filename, int volume, bool skippable);

--- a/src/display/graphics.h
+++ b/src/display/graphics.h
@@ -97,6 +97,7 @@ public:
     
     void lock();
     void unlock();
+    bool isLocked() noexcept;
 
 private:
 	Graphics(RGSSThreadData *data);

--- a/src/display/graphics.h
+++ b/src/display/graphics.h
@@ -67,7 +67,6 @@ public:
     int displayHeight() const;
 	void resizeScreen(int width, int height);
     void resizeWindow(int width, int height, bool center=false);
-	void onSizeChanged();
 	void drawMovieFrame(const THEORAPLAY_VideoFrame* video, Bitmap *videoBitmap);
 	bool updateMovieInput(Movie *movie);
 	void playMovie(const char *filename, int volume, bool skippable);

--- a/src/eventthread.cpp
+++ b/src/eventthread.cpp
@@ -275,9 +275,6 @@ void EventThread::process(RGSSThreadData &rtData)
                         windowSizeMsg.post(Vec2i(winW, winH));
                         drawableSizeMsg.post(Vec2i(drwW, drwH));
                         resetInputStates();
-                        if (shState != nullptr) {
-                            shState->graphics().onSizeChanged();
-                        }
                         break;
                         
                     case SDL_WINDOWEVENT_ENTER :

--- a/src/eventthread.cpp
+++ b/src/eventthread.cpp
@@ -275,6 +275,9 @@ void EventThread::process(RGSSThreadData &rtData)
                         windowSizeMsg.post(Vec2i(winW, winH));
                         drawableSizeMsg.post(Vec2i(drwW, drwH));
                         resetInputStates();
+                        if (shState != nullptr) {
+                            shState->graphics().onSizeChanged();
+                        }
                         break;
                         
                     case SDL_WINDOWEVENT_ENTER :

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -542,7 +542,7 @@ static SDL_GLContext initGL(SDL_Window *win, Config &conf,
   if (conf.debugMode)
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
 
-  /* If supported by the OpenGL driver, use GL_CONTEXT_RELEASE_BEHAVIOR_NONE to allow calling OpenGL from multiple threads without a proxy thread */
+  /* If supported by the OpenGL driver, use GL_CONTEXT_RELEASE_BEHAVIOR to allow calling OpenGL from multiple threads without a proxy thread */
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_RELEASE_BEHAVIOR, SDL_GL_CONTEXT_RELEASE_BEHAVIOR_NONE);
 
   glCtx = SDL_GL_CreateContext(win);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -545,9 +545,15 @@ static SDL_GLContext initGL(SDL_Window *win, Config &conf,
   /* If supported by the OpenGL driver, use GL_CONTEXT_RELEASE_BEHAVIOR to allow calling OpenGL from multiple threads without a proxy thread */
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_RELEASE_BEHAVIOR, SDL_GL_CONTEXT_RELEASE_BEHAVIOR_NONE);
 
-  glCtx = SDL_GL_CreateContext(win);
-
-  if (!glCtx) {
+  if (
+    (SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3), SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2), (glCtx = SDL_GL_CreateContext(win))) == nullptr
+      && (SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3), SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1), (glCtx = SDL_GL_CreateContext(win))) == nullptr
+      && (SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3), SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0), (glCtx = SDL_GL_CreateContext(win))) == nullptr
+#ifndef GLES2_HEADER // Only desktop OpenGL has a version 2.1; OpenGL ES has no version 2.1
+      && (SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2), SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1), (glCtx = SDL_GL_CreateContext(win))) == nullptr
+#endif
+      && (SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2), SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0), (glCtx = SDL_GL_CreateContext(win))) == nullptr
+  ) {
     GLINIT_SHOWERROR(std::string("Could not create OpenGL context: ") + SDL_GetError());
     return 0;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -565,7 +565,7 @@ static SDL_GLContext initGL(SDL_Window *win, Config &conf,
   }
 
   try {
-    initGLFunctions(win, glCtx);
+    initGLFunctions(conf, win, glCtx);
   } catch (const Exception &exc) {
     GLINIT_SHOWERROR(exc.msg);
     SDL_GL_DeleteContext(glCtx);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -223,6 +223,12 @@ int main(int argc, char *argv[]) {
 
     SDL_SetHint(SDL_HINT_IME_SHOW_UI, "1");
 
+    /* When using SDL's X11 video driver,
+     * SDL_GL_MakeCurrent() seems to be faster when using EGL than when using GLX,
+     * so make SDL use EGL instead of GLX when using X11
+     * (you can still make SDL use GLX instead when using X11 by setting the SDL_VIDEO_X11_FORCE_EGL environment variable to 0) */
+    SDL_SetHint(SDL_HINT_VIDEO_X11_FORCE_EGL, "1");
+
     /* initialize SDL first */
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER | SDL_INIT_TIMER) < 0) {
       showInitError(std::string("Error initializing SDL: ") + SDL_GetError());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,9 +70,6 @@ __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 #ifdef MKXPZ_BUILD_XCODE
 #include <Availability.h>
 #include "TouchBar.h"
-#if !defined(__MAC_10_15) || __MAC_OS_X_VERSION_MAX_ALLOWED < __MAC_10_15
-#define MKXPZ_INIT_GL_LATER
-#endif
 #endif
 
 #ifndef MKXPZ_INIT_GL_LATER
@@ -126,7 +123,8 @@ int rgssThreadFun(void *userdata) {
   if (!threadData->glContext)
     return 0;
 #else
-  SDL_GL_MakeCurrent(threadData->window, threadData->glContext);
+  if (gl.context_release_behavior_none)
+    SDL_GL_MakeCurrent(threadData->window, threadData->glContext);
 #endif
 
   /* Setup AL context */
@@ -457,6 +455,12 @@ int main(int argc, char *argv[]) {
 #endif
 
     /* Start RGSS thread */
+#ifndef MKXPZ_INIT_GL_LATER
+    if (gl.context_release_behavior_none && SDL_GL_MakeCurrent(win, nullptr) < 0) {
+      showInitError(std::string("Could not unbind OpenGL context: ") + SDL_GetError());
+      return 0;
+    }
+#endif
     SDL_Thread *rgssThread = SDL_CreateThread(rgssThreadFun, "rgss", &rtData);
 
     /* Start event processing */
@@ -479,9 +483,17 @@ int main(int argc, char *argv[]) {
 
     /* If RGSS thread ack'd request, wait for it to shutdown,
      * otherwise abandon hope and just end the process as is. */
-    if (rtData.rqTermAck)
+    if (rtData.rqTermAck) {
       SDL_WaitThread(rgssThread, 0);
-    else
+      if (gl.thread != nullptr) {
+        {
+          std::lock_guard<std::mutex> guard(gl.mutex);
+          gl.commandId = -1;
+          gl.cond.notify_one();
+        }
+        SDL_WaitThread(gl.thread, 0);
+      }
+    } else
       SDL_ShowSimpleMessageBox(
           SDL_MESSAGEBOX_ERROR, conf.game.title.c_str(),
           std::string("The RGSS script seems to be stuck. "+conf.game.title+" will now force quit.").c_str(),
@@ -530,6 +542,9 @@ static SDL_GLContext initGL(SDL_Window *win, Config &conf,
   if (conf.debugMode)
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
 
+  /* If supported by the OpenGL driver, use GL_CONTEXT_RELEASE_BEHAVIOR_NONE to allow calling OpenGL from multiple threads without a proxy thread */
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_RELEASE_BEHAVIOR, SDL_GL_CONTEXT_RELEASE_BEHAVIOR_NONE);
+
   glCtx = SDL_GL_CreateContext(win);
 
   if (!glCtx) {
@@ -538,7 +553,7 @@ static SDL_GLContext initGL(SDL_Window *win, Config &conf,
   }
 
   try {
-    initGLFunctions();
+    initGLFunctions(win, glCtx);
   } catch (const Exception &exc) {
     GLINIT_SHOWERROR(exc.msg);
     SDL_GL_DeleteContext(glCtx);
@@ -551,12 +566,12 @@ static SDL_GLContext initGL(SDL_Window *win, Config &conf,
 
   gl.ClearColor(0, 0, 0, 1);
   gl.Clear(GL_COLOR_BUFFER_BIT);
-  SDL_GL_SwapWindow(win);
+  gl.SwapWindow(win);
 
   printGLInfo();
 
   bool vsync = conf.vsync || conf.syncToRefreshrate;
-  SDL_GL_SetSwapInterval(vsync ? 1 : 0);
+  gl.SetSwapInterval(vsync ? 1 : 0);
 
   // GLDebugLogger dLogger;
   return glCtx;

--- a/src/sharedstate.cpp
+++ b/src/sharedstate.cpp
@@ -122,7 +122,6 @@ struct SharedStatePrivate
         
         startupTime = std::chrono::steady_clock::now();
         
-
 		/* Shaders have been compiled in ShaderSet's constructor */
 		if (gl.ReleaseShaderCompiler)
 		{

--- a/src/sharedstate.cpp
+++ b/src/sharedstate.cpp
@@ -122,9 +122,14 @@ struct SharedStatePrivate
         
         startupTime = std::chrono::steady_clock::now();
         
+
 		/* Shaders have been compiled in ShaderSet's constructor */
 		if (gl.ReleaseShaderCompiler)
+		{
+			GFX_LOCK;
 			gl.ReleaseShaderCompiler();
+			GFX_UNLOCK;
+		}
 
 		std::string archPath = config.execName + gameArchExt();
 
@@ -152,6 +157,8 @@ struct SharedStatePrivate
 		globalTexW = 128;
 		globalTexH = 64;
 
+		GFX_LOCK;
+
 		globalTex = TEX::gen();
 		TEX::bind(globalTex);
 		TEX::setRepeat(false);
@@ -164,6 +171,8 @@ struct SharedStatePrivate
 		TEXFBO::allocEmpty(gpTexFBO, globalTexW, globalTexH);
 		TEXFBO::linkFBO(gpTexFBO);
 
+		GFX_UNLOCK;
+
 		/* RGSS3 games will call setup_midi, so there's
 		 * no need to do it on startup */
 		if (rgssVer <= 2)
@@ -172,9 +181,11 @@ struct SharedStatePrivate
 
 	~SharedStatePrivate()
 	{
+		GFX_LOCK;
 		TEX::del(globalTex);
 		TEXFBO::fini(gpTexFBO);
 		TEXFBO::fini(atlasTex);
+		GFX_UNLOCK;
 	}
 };
 
@@ -214,9 +225,11 @@ void SharedState::finiInstance()
 {
 	delete SharedState::instance->p->defaultFont;
 
-	delete SharedState::instance;
-
+	GFX_LOCK;
 	delete _globalIBO;
+	GFX_UNLOCK;
+
+	delete SharedState::instance;
 }
 
 void SharedState::setScreen(Scene &screen)


### PR DESCRIPTION
Previously, accessing OpenGL from threads other than the main RGSS thread was unspecified behaviour because the OpenGL context was not being correctly bound to other threads when the OpenGL context was being accessed from other threads. In order to allow multiple threads to access the OpenGL context I have implemented the following algorithm:

* If `Graphics.thread_safe` is `true` (which it is by default), it will choose one of the following two methods of enabling thread-safe access to OpenGL depending on the `multithreadedGl` setting in mkxp.json. If it is set to "automatically choose", then the first option will be used if the `KHR_context_flush_control` extension is supported or the user's machine is an Apple device (CGL, the native OpenGL interface on Apple devices, doesn't support `KHR_context_flush_control` but also doesn't flush the OpenGL context when you bind or unbind it) and the second option will be used otherwise.
  * Option 1: Flushing when the OpenGL context is bound/unbound is disabled via the `KHR_context_flush_control` extension if possible so that the OpenGL context can be moved between threads quickly. Then whenever `GFX_LOCK` is called, the context is bound to the thread that called `GFX_LOCK`, and when `GFX_UNLOCK` is called on the same thread, it's unbound again.
  * Option 2: Start up a separate thread, bind the OpenGL context to that thread and proxy all OpenGL calls through that thread. This is intended to be used as a fallback option for OpenGL drivers where the implicit flushing that occurs when binding or unbinding the OpenGL context cannot be disabled.
* If `Graphics.thread_safe` is `false`, both of the above two workarounds will be disabled, but OpenGL calls from threads outside of the thread that `Graphics.thread_safe` was set to `false` on will throw exceptions.

This should fix crashes in the game Rejuvenation. That game accesses OpenGL state from outside of the main RGSS thread during game startup which caused certain old graphics drivers to crash.

I have also disabled the `MKXPZ_INIT_GL_LATER` workaround. OpenGL initialization works correctly now on all platforms regardless of whether or not `MKXPZ_INIT_GL_LATER` is defined.

Note that this pull request has been shown to cause reduced performance on certain Windows machines, depending on the specific graphics driver. Using ANGLE will fix performance issues on these machines, because ANGLE doesn't flush the pipeline when the OpenGL context is bound/unbound and so supports option 1 with no performance penalty. Note that ANGLE also doesn't support `KHR_context_flush_control` so we'll need to explicitly check for ANGLE once we have ANGLE support on non-macOS platforms.

* Closes #301 