### PR TITLE
Fix Linux build issues and two rendering/crash bugs

### DIFF
--- a/src/display/font.cpp
+++ b/src/display/font.cpp
@@ -534,7 +534,7 @@ static int calc_ppem_for_height(Font_Container *font, int height)
 }
 /* /wine */
 
-_TTF_Font *SharedFontState::getFont(std::string family,
+TTF_Font *SharedFontState::getFont(std::string family,
                                     int size, float hiresMult, int outline_size)
 {
 	std::transform(family.begin(), family.end(), family.begin(),
@@ -686,7 +686,7 @@ bool SharedFontState::fontPresent(std::string family) const
 	return !set->empty();
 }
 
-_TTF_Font *SharedFontState::openBundled(int size)
+TTF_Font *SharedFontState::openBundled(int size)
 {
 	SDL_RWops *ops = openBundledFont();
 
@@ -997,9 +997,9 @@ void Font::initDefaults(const SharedFontState &sfs)
 	FontPrivate::defaultShadow  = (rgssVer == 2 ? true : false);
 }
 
-_TTF_Font *Font::getSdlFont(int outline_size)
+TTF_Font *Font::getSdlFont(int outline_size)
 {
-	_TTF_Font **font;
+	TTF_Font **font;
 	if (outline_size == 0)
 		font = &p->sdlFont;
 	else

--- a/src/display/font.h
+++ b/src/display/font.h
@@ -29,7 +29,7 @@
 #include <string>
 
 struct SDL_RWops;
-struct _TTF_Font;
+struct TTF_Font;
 struct Config;
 
 struct SharedFontStatePrivate;
@@ -47,12 +47,12 @@ public:
 	void initFontSetCB(SDL_RWops &ops,
 	                   const std::string &filename);
 
-	_TTF_Font *getFont(std::string family,
+	TTF_Font *getFont(std::string family,
 	                   int size, float hiresMult, int outline_size = 0);
 
 	bool fontPresent(std::string family) const;
 
-	static _TTF_Font *openBundled(int size);
+	static TTF_Font *openBundled(int size);
     void setDefaultFontFamily(const std::string &family);
 
 private:
@@ -117,7 +117,7 @@ public:
 	static void initDefaults(const SharedFontState &sfs);
 
 	/* internal */
-	_TTF_Font *getSdlFont(int outline_size);
+	TTF_Font *getSdlFont(int outline_size);
 
 private:
 	FontPrivate *p;

--- a/src/display/gl/gl-meta.cpp
+++ b/src/display/gl/gl-meta.cpp
@@ -360,17 +360,20 @@ void blitRectangle(const IntRect &src, const Vec2i &dstPos)
 void blitRectangle(const IntRect &src, const IntRect &dst, bool smooth)
 {
 	// Handle high-res dest
-	int scaledDstX = dst.x * blitDstWidthHires / blitDstWidthLores;
-	int scaledDstY = dst.y * blitDstHeightHires / blitDstHeightLores;
-	int scaledDstWidth = dst.w * blitDstWidthHires / blitDstWidthLores;
-	int scaledDstHeight = dst.h * blitDstHeightHires / blitDstHeightLores;
+	// (guard against div-by-zero: a zero-size lores target/source is
+	// degenerate - e.g. an empty sprite/viewport - so just skip scaling
+	// in that case rather than crashing with SIGFPE)
+	int scaledDstX = blitDstWidthLores ? (dst.x * blitDstWidthHires / blitDstWidthLores) : dst.x;
+	int scaledDstY = blitDstHeightLores ? (dst.y * blitDstHeightHires / blitDstHeightLores) : dst.y;
+	int scaledDstWidth = blitDstWidthLores ? (dst.w * blitDstWidthHires / blitDstWidthLores) : dst.w;
+	int scaledDstHeight = blitDstHeightLores ? (dst.h * blitDstHeightHires / blitDstHeightLores) : dst.h;
 	IntRect dstScaled(scaledDstX, scaledDstY, scaledDstWidth, scaledDstHeight);
 
 	// Handle high-res source
-	int scaledSrcX = src.x * blitSrcWidthHires / blitSrcWidthLores;
-	int scaledSrcY = src.y * blitSrcHeightHires / blitSrcHeightLores;
-	int scaledSrcWidth = src.w * blitSrcWidthHires / blitSrcWidthLores;
-	int scaledSrcHeight = src.h * blitSrcHeightHires / blitSrcHeightLores;
+	int scaledSrcX = blitSrcWidthLores ? (src.x * blitSrcWidthHires / blitSrcWidthLores) : src.x;
+	int scaledSrcY = blitSrcHeightLores ? (src.y * blitSrcHeightHires / blitSrcHeightLores) : src.y;
+	int scaledSrcWidth = blitSrcWidthLores ? (src.w * blitSrcWidthHires / blitSrcWidthLores) : src.w;
+	int scaledSrcHeight = blitSrcHeightLores ? (src.h * blitSrcHeightHires / blitSrcHeightLores) : src.h;
 	IntRect srcScaled(scaledSrcX, scaledSrcY, scaledSrcWidth, scaledSrcHeight);
 
 	if (HAVE_NATIVE_BLIT)

--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -854,7 +854,13 @@ struct GraphicsPrivate {
         glResourceLock = SDL_CreateMutex();
         
         if (integerScaleActive) {
-            integerScaleFactor = Vec2i(0, 0);
+            /* Compute the real initial scale immediately instead of
+             * deferring to the first checkResize() call - scRes/winSize
+             * are already valid at this point, and leaving the scale at
+             * (0, 0) here allocates integerScaleBuffer at 0x0, which stays
+             * that way (rendering solid black) if a redraw happens before
+             * checkResize() gets a chance to fix it up. */
+            findHighestIntegerScale();
             rebuildIntegerScaleBuffer();
         }
         

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,7 @@
 physfs = dependency('physfs', version: '>=2.1', static: build_static)
 openal = dependency('openal', static: build_static, method: 'pkg-config')
 theora = dependency('theora', static: build_static)
+theoradec = dependency('theoradec', static: build_static)
 vorbisfile = dependency('vorbisfile', static: build_static)
 vorbis = dependency('vorbis', static: build_static)
 ogg = dependency('ogg', static: build_static)
@@ -96,7 +97,7 @@ global_include_dirs += include_directories('.',
     'util', 'util/sigslot', 'util/sigslot/adapter'
 )
 
-global_dependencies += [openal, zlib, bz2, sdl2, sdl_sound, pixman, physfs, theora, vorbisfile, vorbis, ogg, sdl2_ttf, freetype, sdl2_image, png, iconv, uchardet]
+global_dependencies += [openal, zlib, bz2, sdl2, sdl_sound, pixman, physfs, theora, theoradec, vorbisfile, vorbis, ogg, sdl2_ttf, freetype, sdl2_image, png, iconv, uchardet]
 if host_system == 'windows'
     global_dependencies += compilers['cpp'].find_library('wsock32')
 endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -34,8 +34,8 @@ else
     bz2 = compilers['cpp'].find_library('bz2')
     # FIXME: Specifically asking for static doesn't work if iconv isn't
     # installed in the system prefix somewhere
-    iconv = compilers['cpp'].find_library('iconv')
-    global_dependencies += compilers['cpp'].find_library('charset')
+    iconv = compilers['cpp'].find_library('iconv', required: false)
+    global_dependencies += compilers['cpp'].find_library('charset', required: false)
 endif
 
 # If OpenSSL is present, you get HTTPS support


### PR DESCRIPTION
## Summary

Five small, independent fixes found while building and running mkxp-z on an Arch-based Linux distro (SDL2_ttf 2.24, libtheora 1.2.0 packaging):

- **TTF_Font type mismatch**: font.h forward-declared its own `_TTF_Font` type, which matched the real struct tag on older SDL2_ttf by coincidence. SDL2_ttf 2.24.0 renamed the real tag to `TTF_Font`, breaking every function that passes a font pointer between font.h and SDL_ttf calls. Renamed the forward-declared type to match.
- **iconv/charset build failure on Linux**: `find_library('iconv'/'charset')` fails to find a standalone library on glibc systems, where iconv is part of libc itself, aborting `meson setup` entirely. Marked both `required: false`.
- **theoradec linking failure**: newer libtheora (1.2.0+) splits the modern `th_*` decode API out of `libtheora.so` into a separate `libtheoradec.so`. theoraplay.c uses that API, so builds against this newer packaging fail at link time. Added `theoradec` as an explicit dependency.
- **SIGFPE crash in `GLMeta::blitRectangle`**: divides by a texture's width/height to translate between low/high-res buffers; a texture can legitimately be zero-size in degenerate cases (e.g. an empty sprite/viewport), and integer division by zero traps as SIGFPE, crashing the whole process. Added a guard.
- **Black screen from a 0x0 integer-scale buffer**: when integer scaling is active, the buffer is deliberately allocated at 0x0 in the constructor as a placeholder, expecting the first `checkResize()` call to fix the size before any real drawing happens. If a redraw races ahead of that first resize, the buffer stays 0x0 forever, rendering solid black every frame after. Computed the real initial scale immediately instead of deferring it.

## Test plan
- [x] Built cleanly with meson + ninja on Arch Linux (SDL2_ttf 2.24.0, libtheora 1.2.0)
- [x] Verified the font/theora fixes let the build complete at all
- [x] Reproduced and confirmed the SIGFPE crash and the black-screen bug independently, verified both are gone after the fixes, with no regressions across several other RGSS games tested (XP/VX/VX Ace, various configs)