### PR TITLE
Fix the return value of `GetKeyState` in win32_wrap.rb

### DIFF
--- a/scripts/preload/win32_wrap.rb
+++ b/scripts/preload/win32_wrap.rb
@@ -263,8 +263,9 @@ module Win32API_Impl
 		end
 
 		class GetKeyState
+			PRESSED_BIT = (1 << 15)
 			def call(vkey)
-				return common_keystate(vkey[0])
+				return common_keystate(vkey[0]) == 1 ? PRESSED_BIT : 0
 			end
 		end
 		class GetAsyncKeyState


### PR DESCRIPTION
In the [documentation for this function](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getkeystate#return-value), it's specified that whether or not the key is pressed is returned in the most-significant bit (i.e. bit 15, since the return value is `SHORT` which is a 16-bit integer).

* Closes #375 