### PR TITLE
Fix an out-of-bounds read in `advanceMagicN()` in src/crypto/rgssad.cpp

### DIFF
--- a/src/crypto/rgssad.cpp
+++ b/src/crypto/rgssad.cpp
@@ -131,6 +131,9 @@ advanceMagicN(uint32_t &magic, uint32_t n) {
     uint32_t old = magic;
     int table_index = 0;
 
+    /* The LCG table only goes up to the LCG's period of 2^30, so perform a bitwise AND with 2^30 - 1 */
+    n &= (uint32_t)0x3fffffff;
+
     while (n != 0) {
         if (n & 1) {
             magic = magic * LCG_TABLE[table_index][0] + LCG_TABLE[table_index][1];


### PR DESCRIPTION
Seeking an RGSSAD archive forwards by at least 1 GiB or backwards by any length is currently undefined behaviour because it causes `advanceMagicN()` to read an out-of-bounds index of `LCG_TABLE`.

This pull request fixes it by performing a bitwise AND of the seek size with one less than the period of the LCG to prevent `table_index` from going out of bounds.