### PR TITLE
Fix serialization bugs on big-endian platforms

### DIFF
--- a/src/crypto/rgssad.cpp
+++ b/src/crypto/rgssad.cpp
@@ -21,6 +21,7 @@
 
 #include "rgssad.h"
 #include "boost-hash.h"
+#include "serial-util.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -190,6 +191,7 @@ RGSS_ioRead(PHYSFS_Io *self, void *buffer, PHYSFS_uint64 len)
 	{
 		uint32_t dword;
 		io->read(io, &dword, preAlign);
+		dword = byteSwap32IfBigEndian(dword);
 
 		/* Need to align the bytes with the
 		 * magic before xoring */
@@ -198,6 +200,7 @@ RGSS_ioRead(PHYSFS_Io *self, void *buffer, PHYSFS_uint64 len)
 
 		/* Shift them back to normal */
 		dword >>= 8 * (offs % 4);
+		dword = byteSwap32IfBigEndian(dword);
 		memcpy(bBufferP, &dword, preAlign);
 
 		bBufferP += preAlign;
@@ -218,7 +221,7 @@ RGSS_ioRead(PHYSFS_Io *self, void *buffer, PHYSFS_uint64 len)
 
 		/* Then xor them */
 		for (uint64_t i = 0; i < (align / 4); ++i)
-			dwBufferP[i] ^= advanceMagic(entry->currentMagic);
+			dwBufferP[i] ^= byteSwap32IfBigEndian(advanceMagic(entry->currentMagic));
 
 		bBufferP += align;
 	}
@@ -229,7 +232,7 @@ RGSS_ioRead(PHYSFS_Io *self, void *buffer, PHYSFS_uint64 len)
 		io->read(io, &dword, postAlign);
 
 		/* Bytes are already aligned with magic */
-		dword ^= entry->currentMagic;
+		dword ^= byteSwap32IfBigEndian(entry->currentMagic);
 		memcpy(bBufferP, &dword, postAlign);
 	}
 

--- a/src/etc/table.cpp
+++ b/src/etc/table.cpp
@@ -115,7 +115,12 @@ void Table::serialize(char *buffer) const
 	writeInt32(&buffer, zs);
 	writeInt32(&buffer, size);
 
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+	for (int i = 0; i < size; ++i)
+		((uint16_t *)buffer)[i] = byteSwap16(dataPtr(data)[i]);
+#else
 	memcpy(buffer, dataPtr(data), sizeof(int16_t)*size);
+#endif
 }
 
 
@@ -137,7 +142,12 @@ Table *Table::deserialize(const char *data, int len)
 		throw Exception(Exception::RGSSError, "Marshal: Table: bad file format");
 
 	Table *t = new Table(x, y, z);
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+	for (int i = 0; i < size; ++i)
+		dataPtr(t->data)[i] = byteSwap16(((uint16_t *)data)[i]);
+#else
 	memcpy(dataPtr(t->data), data, sizeof(int16_t)*size);
+#endif
 
 	return t;
 }

--- a/src/util/serial-util.h
+++ b/src/util/serial-util.h
@@ -35,7 +35,7 @@ byteSwap16(uint16_t value)
 	static_assert(sizeof(unsigned short) == sizeof(uint16_t), "unsigned short should be 16 bits");
 	return _byteswap_ushort(value);
 #else
-	return __builtin_bswap32(value);
+	return __builtin_bswap16(value);
 #endif
 }
 

--- a/src/util/serial-util.h
+++ b/src/util/serial-util.h
@@ -98,9 +98,7 @@ readInt32(const char **dataP)
 	memcpy(&result, *dataP, 4);
 	*dataP += 4;
 
-#if SDL_BYTEORDER == SDL_BIG_ENDIAN
-	result = byteSwap32(result);
-#endif
+	result = byteSwap32IfBigEndian(result);
 
 	return result;
 }
@@ -130,9 +128,7 @@ readDouble(const char **dataP)
 static inline void
 writeInt32(char **dataP, int32_t value)
 {
-#if SDL_BYTEORDER == SDL_BIG_ENDIAN
-	value = byteSwap32(value);
-#endif
+	value = byteSwap32IfBigEndian(value);
 
 	memcpy(*dataP, &value, 4);
 	*dataP += 4;

--- a/src/util/serial-util.h
+++ b/src/util/serial-util.h
@@ -28,6 +28,68 @@
 
 #include <SDL_endian.h>
 
+static inline uint16_t
+byteSwap16(uint16_t value)
+{
+#ifdef _MSC_VER
+	static_assert(sizeof(unsigned short) == sizeof(uint16_t), "unsigned short should be 16 bits");
+	return _byteswap_ushort(value);
+#else
+	return __builtin_bswap32(value);
+#endif
+}
+
+static inline uint16_t
+byteSwap16IfBigEndian(uint16_t value)
+{
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+	return byteSwap16(value);
+#else
+	return value;
+#endif
+}
+
+static inline uint32_t
+byteSwap32(uint32_t value)
+{
+#ifdef _MSC_VER
+	static_assert(sizeof(unsigned long) == sizeof(uint32_t), "unsigned long should be 32 bits");
+	return _byteswap_ulong(value);
+#else
+	return __builtin_bswap32(value);
+#endif
+}
+
+static inline uint32_t
+byteSwap32IfBigEndian(uint32_t value)
+{
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+	return byteSwap32(value);
+#else
+	return value;
+#endif
+}
+
+static inline uint64_t
+byteSwap64(uint64_t value)
+{
+#ifdef _MSC_VER
+	return _byteswap_uint64(value);
+#else
+	return __builtin_bswap64(value);
+#endif
+}
+
+static inline uint64_t
+byteSwap64IfBigEndian(uint64_t value)
+{
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+	return byteSwap64(value);
+#else
+	return value;
+#endif
+}
+
 static inline int32_t
 readInt32(const char **dataP)
 {
@@ -37,12 +99,7 @@ readInt32(const char **dataP)
 	*dataP += 4;
 
 #if SDL_BYTEORDER == SDL_BIG_ENDIAN
-#  ifdef _MSC_VER
-	static_assert(sizeof(unsigned long) == sizeof(int32_t), "unsigned long should be 32 bits");
-	result = (int32_t)_byteswap_ulong((unsigned long)result);
-#  else
-	result = (int32_t)__builtin_bswap32((uint32_t)result);
-#  endif
+	result = byteSwap32(result);
 #endif
 
 	return result;
@@ -57,11 +114,7 @@ readDouble(const char **dataP)
 	memcpy(&result, *dataP, 8);
 	*dataP += 8;
 
-#  ifdef _MSC_VER
-	result = (uint64_t)_byteswap_uint64((unsigned __int64)result);
-#  else
-	result = __builtin_bswap64(result);
-#  endif
+	result = byteSwap64(result);
 
 	return *(double *)&result;
 #else
@@ -78,12 +131,7 @@ static inline void
 writeInt32(char **dataP, int32_t value)
 {
 #if SDL_BYTEORDER == SDL_BIG_ENDIAN
-#  ifdef _MSC_VER
-	static_assert(sizeof(unsigned long) == sizeof(int32_t), "unsigned long should be 32 bits");
-	value = (int32_t)_byteswap_ulong((unsigned long)value);
-#  else
-	value = (int32_t)__builtin_bswap32((uint32_t)value);
-#  endif
+	value = byteSwap32(value);
 #endif
 
 	memcpy(*dataP, &value, 4);
@@ -96,11 +144,7 @@ writeDouble(char **dataP, double value)
 #if SDL_BYTEORDER == SDL_BIG_ENDIAN
 	uint64_t valueUint = *(uint64_t *)&value;
 
-#  ifdef _MSC_VER
-	valueUint = (uint64_t)_byteswap_uint64((unsigned __int64)valueUint);
-#  else
-	valueUint = __builtin_bswap64(valueUint);
-#  endif
+	valueUint = byteSwap64(valueUint);
 
 	memcpy(*dataP, &valueUint, 8);
 #else


### PR DESCRIPTION
This pull request fixes the code for reading RGSSAD archives and reading/writing tables on big-endian platforms.

You can test it out on a Linux machine by running one of the Ubuntu s390x builds from GitHub Actions using QEMU user-mode emulation. First, install QEMU user-mode emulation with binfmt support, which can be done, for example, by installing the `qemu-user-binfmt` package on Ubuntu 25.10 or later or `qemu-user-static` on older Ubuntu versions, or `qemu-user-static-binfmt` on Arch Linux. Then you can run s390x binaries in a Ubuntu Docker image (QEMU user-mode emulation should be used automatically):

```
docker run --platform linux/s390x ubuntu:resolute
```

To test out the Ubuntu s390x builds of mkxp-z you can use these commands in the Ubuntu Docker image (note: I've been testing with the builds from #342; the builds from the current dev branch might require additional libraries):

```
apt update
apt install -y libx11-6 libxcursor1 libxext6 libxfixes3 libxi6 libxrandr2 xvfb
cat << 'EOF' > alsoft.conf
  [General]
  drivers = null
EOF
xvfb-run ./mkxp-z.s390x
```